### PR TITLE
Jenkinsfiles for merge builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
             steps {
                 // Currently running on a build node with multiple jobs so incorrect jar may be cached
                 // (Moving to Docker should fix this)
-                sh 'gradle --init-script init-ci.gradle publishToMavenLocal --refresh-dependencies'
+                sh 'gradle --init-script init-ci.gradle publishToMavenLocal build --refresh-dependencies'
             }
         }
         stage('Deploy') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,37 @@
+pipeline {
+    agent {
+        label 'testintegration'
+    }
+
+    environment {
+        // Default credentials for testing on devspace
+        MAVEN_SNAPSHOTS_REPO_URL = 'http://nexus:8081/nexus/repository/maven-internal/'
+        MAVEN_USER = 'admin'
+        MAVEN_PASSWORD = 'admin123'
+
+        // Disable Gradle daemon
+        GRADLE_OPTS = '-Dorg.gradle.daemon=false'
+    }
+
+    stages {
+        stage('Build') {
+            steps {
+                // Currently running on a build node with multiple jobs so incorrect jar may be cached
+                // (Moving to Docker should fix this)
+                sh 'gradle --init-script init-ci.gradle publishToMavenLocal --refresh-dependencies'
+            }
+        }
+        stage('Deploy') {
+            steps {
+                sh 'gradle --init-script init-ci.gradle publish'
+            }
+        }
+    }
+
+    post {
+        always {
+            // Cleanup workspace
+            deleteDir()
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
         stage('Deploy') {
             steps {
                 sh 'gradle --init-script init-ci.gradle publish'
+                archiveArtifacts artifacts: 'build/distributions/*.zip'
             }
         }
     }

--- a/Jenkinsfile.merge
+++ b/Jenkinsfile.merge
@@ -1,0 +1,51 @@
+pipeline {
+    agent {
+        label 'testintegration'
+    }
+
+    parameters {
+        choice(
+            name: 'STATUS',
+            choices: ['success-only', 'no-error', 'none'],
+            description: 'PR check status'
+        )
+        string(
+            name: 'MERGE_OPTIONS',
+            defaultValue: '-vvv --no-ask --reset --comment',
+            description: 'scc merge options'
+        )
+    }
+
+    environment {
+        // These optional environment variables can be set in
+        // Manage Jenkins → Configure System → Global properties → Environment variables
+
+        // MERGE_PUSH_BRANCH the branch that merges should be pushed to, default "merge"
+        // MERGE_GIT_USER the GitHub user that the repo branches should be pushed to
+        //   default is the owner of the CI node's GitHub token
+
+        BASE_REPO = 'omero-insight.git'
+    }
+
+    stages {
+        stage('Merge') {
+            steps {
+                // build is in .gitignore so we can use it as a temp dir
+                sh 'mkdir build'
+                sh 'cd build && curl -sfL https://github.com/ome/build-infra/archive/master.tar.gz | tar -zxf -'
+                sh 'virtualenv build/venv && build/venv/bin/pip install scc'
+                sh """
+                    . build/venv/bin/activate
+                    if [ "${env.MERGE_PUSH_BRANCH}" != "null" ]; then
+                        export PUSH_BRANCH=${env.MERGE_PUSH_BRANCH}
+                    fi
+                    if [ "${env.MERGE_GIT_USER}" != "null" ]; then
+                        export GIT_USER=${env.MERGE_GIT_USER}
+                    fi
+                    export STATUS=${params.STATUS} MERGE_OPTIONS="${params.MERGE_OPTIONS}"
+                    bash build/build-infra-master/recursive-merge
+                """
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "org.openmicroscopy"
-version = "5.5.0-m1"
+version = "5.5.0-SNAPSHOT"
 targetCompatibility = JavaVersion.VERSION_1_8
 sourceCompatibility = JavaVersion.VERSION_1_8
 

--- a/init-ci.gradle
+++ b/init-ci.gradle
@@ -1,0 +1,23 @@
+settingsEvaluated {
+    it.pluginManagement {
+        repositories {
+            maven {
+                url System.getenv("ARTIFACTORY_URL") ?: 'https://artifacts.openmicroscopy.org/artifactory/maven/'
+            }
+            maven {
+                url System.getenv("GITLAB_URL") ?: 'https://artifacts.openmicroscopy.org/artifactory/maven/'
+            }
+            maven {
+                url System.getenv("MAVEN_RELEASES_REPO_URL") ?: 'https://artifacts.openmicroscopy.org/artifactory/maven/'
+            }
+            maven {
+                url System.getenv("MAVEN_SNAPSHOTS_REPO_URL") ?: 'https://artifacts.openmicroscopy.org/artifactory/maven/'
+            }
+            gradlePluginPortal()
+        }
+    }
+}
+
+// Use a local m2 repo to ensure a clean build
+// Disabled due to broken SNAPSHOT handling.
+// System.setProperty("maven.repo.local", System.getProperty("user.dir") + "/m2/repository")


### PR DESCRIPTION
These files will be used by devspace to merge all
open omero-insight PRs, push the resulting commit
to snoopycrimecop, and then build local artifacts.

see: https://github.com/openmicroscopy/devspace/pull/127