### PR TITLE
Add javax.activation dep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,9 @@ dependencies {
     implementation("org.jfree:jfreechart:1.0.19")
     implementation("org.openmicroscopy:omero-blitz:5.5.0-m4")
     implementation("org.swinglabs:swingx:1.6.1")
-    implementation("javax.activation:activation:1.1.1")
+    if (JavaVersion.current().isJava9Compatible()) {
+        implementation("javax.activation:activation:1.1.1")
+    }
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation("org.jfree:jfreechart:1.0.19")
     implementation("org.openmicroscopy:omero-blitz:5.5.0-m4")
     implementation("org.swinglabs:swingx:1.6.1")
+    implementation("javax.activation:activation:1.1.1")
 }
 
 application {


### PR DESCRIPTION
Add a dependency for `javax.activation`. This is needed in order to be able to build with Java > 9.
