### PR TITLE
Add omero-java-gateway dep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@ repositories {
 dependencies {
     testImplementation("junit:junit:4.12")
 
+    implementation("org.openmicroscopy:omero-java-gateway:5.5.0-m1")
+
     implementation("com.mortennobel:java-image-scaling:0.8.6")
     implementation("com.google.code.gson:gson:2.8.5")
     implementation("com.zeroc:glacier2:3.6.4")
@@ -30,7 +32,6 @@ dependencies {
     implementation("org.apache.httpcomponents:httpclient:4.5.7")
     implementation("org.apache.httpcomponents:httpcomponents-client:4.5.7")
     implementation("org.jfree:jfreechart:1.0.19")
-    implementation("org.openmicroscopy:omero-blitz:5.5.0-m5")
     implementation("org.swinglabs:swingx:1.6.1")
     if (JavaVersion.current().isJava9Compatible()) {
         implementation("javax.activation:activation:1.1.1")


### PR DESCRIPTION
Replace `omero-blitz` dependency with `omero-java-gateway`.

--exclude  `omero-java-gateway.jar` not available on artifactory yet.
