### PR TITLE
Javadoc

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/dataBrowser/IconManager.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/dataBrowser/IconManager.java
@@ -1,6 +1,4 @@
 /*
- * org.openmicroscopy.shoola.agents.dataBrowser.IconManager 
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
@@ -23,11 +21,6 @@
 package org.openmicroscopy.shoola.agents.dataBrowser;
 
 
-//Java imports
-
-//Third-party libraries
-
-//Application-internal dependencies
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.ui.AbstractIconManager;
 
@@ -46,9 +39,6 @@ import org.openmicroscopy.shoola.env.ui.AbstractIconManager;
  * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
  * @version 3.0
- * <small>
- * (<b>Internal version:</b> $Revision: $Date: $)
- * </small>
  * @since OME3.0
  */
 public class IconManager extends AbstractIconManager
@@ -168,7 +158,7 @@ public class IconManager extends AbstractIconManager
     /** The <code>Report</code> icon. */
     public static final int REPORT = 37;
 
-    /** The <48x48 code>Report</code> icon. */
+    /** The 48x48 <code>Report</code> icon. */
     public static final int REPORT_48 = 38;
 
     /** The 48x48 <code>Save As</code> icon. */

--- a/src/main/java/org/openmicroscopy/shoola/agents/dataBrowser/browser/Thumbnail.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/dataBrowser/browser/Thumbnail.java
@@ -1,6 +1,4 @@
 /*
- * org.openmicroscopy.shoola.agents.dataBrowser.browser.Thumbnail 
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
@@ -23,16 +21,11 @@
 package org.openmicroscopy.shoola.agents.dataBrowser.browser;
 
 
-//Java imports
 import java.awt.Dimension;
 import java.awt.image.BufferedImage;
 import javax.swing.Icon;
 
 import org.openmicroscopy.shoola.util.image.geom.Factory;
-
-//Third-party libraries
-
-//Application-internal dependencies
 
 /** 
  * Defines the functionality required of a thumbnail provider.
@@ -42,9 +35,6 @@ import org.openmicroscopy.shoola.util.image.geom.Factory;
  * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
  * @version 3.0
- * <small>
- * (<b>Internal version:</b> $Revision: $Date: $)
- * </small>
  * @since OME3.0
  */
 public interface Thumbnail
@@ -94,7 +84,8 @@ public interface Thumbnail
     /** 
      * Scales the thumbnail.
      * 
-     * @param f scaling factor. Must be a value strictly positive and <=1.
+     * @param f scaling factor.
+     *        Must be a value strictly positive and less or equals to 1.
      */
     public void scale(double f);
     

--- a/src/main/java/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/measurement/view/GraphPane.java
@@ -103,7 +103,7 @@ public class GraphPane
 	/** Reference to the controller. */
 	private MeasurementViewerControl controller;
 
-	/** The map of <ROIShape, ROIStats> .*/
+	/** The map of {@code <ROIShape, ROIStats>} .*/
 	private Map ROIStats;
 
 	/** The slider controlling the movement of the analysis through Z. */

--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/rnd/Renderer.java
@@ -206,7 +206,7 @@ public interface Renderer
     //CodomainMapContext getCodomainMapContext(Class mapType);
 
     /**
-     * Fired if the color model has been changed from RGB -> Greyscale or
+     * Fired if the color model has been changed from RGB &rarr; Greyscale or
      * vice versa.
      */
     void setColorModelChanged();

--- a/src/main/java/org/openmicroscopy/shoola/agents/util/EditorUtil.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/util/EditorUtil.java
@@ -2612,10 +2612,10 @@ public class EditorUtil
     }
 
     /**
-     * Returns <code>true</code> if the node can be transfered,
+     * Returns <code>true</code> if the node can be transferred,
      * <code>false</code> otherwise.
      *
-     * @param target The target of the D&D action.
+     * @param target The target of the DnD action.
      * @param src The node to transfer.
      * @param userID The id of the user currently logged in.
      * @return See above.

--- a/src/main/java/org/openmicroscopy/shoola/agents/util/dnd/DnDTree.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/util/dnd/DnDTree.java
@@ -91,7 +91,7 @@ public class DnDTree
 	implements DragSourceListener, DropTargetListener, DragGestureListener
 {
 
-	/** Bound property indicating that the D&D is completed.*/
+	/** Bound property indicating that the DnD is completed.*/
 	public static final String DRAGGED_PROPERTY = "dragged";
 	
 	/** The supported flavors.*/
@@ -147,10 +147,10 @@ public class DnDTree
     /** Track the last mouse drag position */
     private Point lastPosition;
 
-    /** outer DnD autoscroll rectable */
+    /** outer DnD autoscroll rectangle */
     private Rectangle outer;
 
-    /** inner DnD autoscroll rectable */
+    /** inner DnD autoscroll rectangle */
     private Rectangle inner;
 
     /** DnD autoscroll timer */
@@ -285,8 +285,7 @@ public class DnDTree
 	
 	/** 
 	 * Creates a ghost image.
-	 * 
-	 * @param path The selected path.
+	 *
 	 * @param p The origin of the dragging.
 	 */
 	private void createGhostImage(Point p)
@@ -412,6 +411,7 @@ public class DnDTree
 
 	/**
 	 * Autoscroll to position
+	 * @param p The position.
 	 */
     private void autoscroll(Point position) {
         Scrollable s = (Scrollable) this;

--- a/src/main/java/org/openmicroscopy/shoola/agents/util/dnd/ObjectToTransfer.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/util/dnd/ObjectToTransfer.java
@@ -1,6 +1,4 @@
 /*
- * org.openmicroscopy.shoola.agents.util.dnd.ObjectToTransfer 
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2011 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
@@ -29,7 +27,7 @@ import java.util.List;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
 
 /** 
- * The D&D objects to transfer and the target.
+ * The DnD objects to transfer and the target.
  *
  * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>

--- a/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
@@ -1,6 +1,4 @@
 /*
- * org.openmicroscopy.shoola.env.LookupNames
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
@@ -22,11 +20,6 @@
  */
 package org.openmicroscopy.shoola.env;
 
-//Java imports
-
-//Third-party libraries
-
-//Application-internal dependencies
 
 /** 
  * Its static fields contain the names that have to be used for looking up
@@ -122,7 +115,7 @@ public class LookupNames
 
     /** 
      * Field to check if the server version is 5.4.8 or later.
-     * TODO: Can be removed for >= 5.5.0 release
+     * TODO: Can be removed for 5.5.0 release
      * */
     public static final String SERVER_5_4_8_OR_LATER = "5.4.8 or later";
     
@@ -215,7 +208,7 @@ public class LookupNames
     /** Field to access the <code>OMERO</code> service information. */
     public static final String OMERODS = "/services/OMERODS";
 
-    /** Field to access the <code>L&F</code> information. */
+    /** Field to access the <code>Look And Feel</code> information. */
     public static final String LOOK_N_FEEL = "LookAndFeel";
 
     /** Field to access the <code>Icons factory</code> information. */

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/DataHandlerView.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/DataHandlerView.java
@@ -179,7 +179,7 @@ public interface DataHandlerView
 	/**
 	 * Resets the rendering settings used by the owner of the images contained 
 	 * in the specified datasets.
-	 * If the rootType is <code>ImageData</code, resets the settings to the 
+	 * If the rootType is <code>ImageData</code>, resets the settings to the
 	 * passed images.
 	 * 
 	 * @param ctx The security context.

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/RenderingSettingsSaver.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/RenderingSettingsSaver.java
@@ -310,7 +310,7 @@ extends BatchCallTree
      * 
      * @param ctx The security context.
      * @param rootNodeType The type of nodes. Can either be 
-     *                      code>ImageData</code>, <code>DatasetData</code>, 
+     *                      <code>ImageData</code>, <code>DatasetData</code>,
      *                      <code>ProjectData</code>, <code>ScreenData</code>,
      *                      <code>PlateData</code>.
      * @param ids The nodes to apply settings to. Mustn't be <code>null</code>.
@@ -332,7 +332,7 @@ extends BatchCallTree
      * @param ctx The security context.
      * @param pixelsID The id of the pixels set of reference.
      * @param rootNodeType The type of nodes. Can either be 
-     *                     code>ImageData</code>, <code>DatasetData</code>.
+     *                     <code>ImageData</code>, <code>DatasetData</code>.
      * @param ids The nodes to apply settings to. Mustn't be <code>null</code>.
      */
     public RenderingSettingsSaver(SecurityContext ctx, long pixelsID,

--- a/src/main/java/org/openmicroscopy/shoola/env/init/SplashScreenInit.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/init/SplashScreenInit.java
@@ -1,6 +1,4 @@
 /*
- * org.openmicroscopy.shoola.env.init.SplashScreenInit
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
@@ -34,7 +32,7 @@ import org.openmicroscopy.shoola.env.ui.UserNotifier;
 
 /** 
  * Does some configuration required for the initialization process to run.
- * Loads L&F, registers for initialization progress notification and
+ * Loads the Look And Feel, registers for initialization progress notification and
  * pops up the splash screen. When the initialization process is finished,
  * we wait until user's credentials are available and then try to log into
  * <i>OMEDS</i>.
@@ -44,10 +42,7 @@ import org.openmicroscopy.shoola.env.ui.UserNotifier;
  * @author  <br>Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
  * 				<a href="mailto:a.falconi@dundee.ac.uk">
  * 					a.falconi@dundee.ac.uk</a>
- * @version 2.2 
- * <small>
- * (<b>Internal version:</b> $Revision$ $Date$)
- * </small>
+ * @version 2.2
  * @since OME2.2
  */
 
@@ -86,8 +81,7 @@ public final class SplashScreenInit
 	 * Does nothing, as this task only requires configuration.
 	 * @see InitializationTask#execute()
 	 */
-	void execute() 
-		throws StartupException
+	void execute()
 	{
 		splashScreen = UIFactory.makeSplashScreen(container);
 		splashScreen.open();

--- a/src/main/java/org/openmicroscopy/shoola/util/concur/ControlFlowObserver.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/concur/ControlFlowObserver.java
@@ -1,6 +1,4 @@
 /*
- * org.openmicroscopy.shoola.util.concur.ControlFlowObserver
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006 University of Dundee. All rights reserved.
  *
@@ -23,20 +21,13 @@
 
 package org.openmicroscopy.shoola.util.concur;
 
-
-//Java imports
-
-//Third-party libraries
-
-//Application-internal dependencies
-
 /** 
  * Provides a testing contract for classes designed to operate in a 
  * multi-threaded environment.
  * Each class in the <code>concur</code> packages should define "check points"
  * in the object life-line at which execution can be manipulated in order to
- * simulate race conditions, resource contemption, etc.  When a check point is
- * reached observers are notified &151; observers implement this interface. 
+ * simulate race conditions, resource contention, etc.  When a check point is
+ * reached observers are notified, observers implement this interface.
  * This allows testing code to coordinate multiple threads that are in a given
  * object at the same time.
  * 
@@ -46,9 +37,6 @@ package org.openmicroscopy.shoola.util.concur;
  * 				<a href="mailto:a.falconi@dundee.ac.uk">
  * 					a.falconi@dundee.ac.uk</a>
  * @version 2.2
- * <small>
- * (<b>Internal version:</b> $Revision$ $Date$)
- * </small>
  * @since OME2.2
  */
 public interface ControlFlowObserver

--- a/src/main/java/org/openmicroscopy/shoola/util/file/ExcelWriter.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/file/ExcelWriter.java
@@ -1,7 +1,5 @@
 /*
- * org.openmicroscopy.shoola.util.file.MSWriter 
- *
-  *------------------------------------------------------------------------------
+ *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
  *
  *
@@ -23,8 +21,6 @@
 package org.openmicroscopy.shoola.util.file;
 
 
-
-//Java imports
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.image.BufferedImage;
@@ -41,8 +37,6 @@ import java.util.Map.Entry;
 import javax.swing.table.TableModel;
 
 
-
-//Third-party libraries
 import org.apache.poi.common.usermodel.HyperlinkType;
 import org.apache.poi.hssf.usermodel.HSSFCell;
 import org.apache.poi.hssf.usermodel.HSSFCellStyle;
@@ -55,9 +49,7 @@ import org.apache.poi.hssf.usermodel.HSSFPatriarch;
 import org.apache.poi.hssf.usermodel.HSSFRichTextString;
 import org.apache.poi.hssf.usermodel.HSSFSheet;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
-import org.apache.poi.hssf.util.HSSFColor;
 
-//Application-internal dependencies
 import org.apache.poi.hssf.util.HSSFColor.HSSFColorPredefined;
 import org.apache.poi.ss.usermodel.BorderStyle;
 import org.apache.poi.ss.usermodel.ClientAnchor;
@@ -630,7 +622,7 @@ public class ExcelWriter
 	
 	/**
 	 * Writes the image with name imageName to the work sheet, at the 
-	 * specified location (rowStart, colStart)->(rowEnd, colEnd).
+	 * specified location (rowStart, colStart)&rarr;(rowEnd, colEnd).
 	 * Returns the (colEnd, rowEnd).
 	 * 
 	 * @param rowStartIndex The index of the start row.

--- a/src/main/java/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
@@ -535,7 +535,7 @@ public class ROIReader {
      * otherwise.
      *
      * @param f The file to save the results to.
-     * @return Returns <c
+     * @return See above
      */
     public boolean readResults(File f)
         throws IOException
@@ -550,6 +550,7 @@ public class ROIReader {
      * otherwise.
      *
      * @param f The file to save the results to.
+     * @return See above
      */
     public boolean readResults(String f)
         throws IOException

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/ColouredButton.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/ColouredButton.java
@@ -1,6 +1,4 @@
 /*
- * org.openmicroscopy.shoola.util.ui.ColouredButton
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
@@ -23,8 +21,6 @@
 
 package org.openmicroscopy.shoola.util.ui;
 
-
-//Java imports
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.image.BufferedImage;
@@ -33,9 +29,6 @@ import javax.swing.DefaultButtonModel;
 import javax.swing.JButton;
 
 
-//Third-party libraries
-
-//Application-internal dependencies
 
 /** 
  * Customized button used to select the rendered channel.
@@ -45,9 +38,6 @@ import javax.swing.JButton;
  * @author	Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
  * 				<a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
  * @version 3.0
- * <small>
- * (<b>Internal version:</b> $Revision: $ $Date: $)
- * </small>
  * @since OME2.2
  */
 public class ColouredButton
@@ -187,8 +177,8 @@ public class ColouredButton
 	}
 
 	/**
-	 * Overridden. Does nothing as it's overwritten by L&F and breaks the 
-	 * colored button.
+	 * Overridden. Does nothing as it's overwritten by the Look And Feel
+	 * and breaks the colored button.
 	 * @see javax.swing.JComponent#setBackground(Color)
 	 */
 	public void setBackground(Color c) {}

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -1,6 +1,4 @@
 /*
- * org.openmicroscopy.shoola.util.ui.UIUtilities
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
@@ -1222,16 +1220,13 @@ public class UIUtilities
     }
     
     /**
-     * Sets the UI properties of the button to unify the L&F.
+     * Sets the UI properties of the button to unify the Look and Feel.
      * 
      * @param b The button.
      */
     public static void unifiedButtonLookAndFeel(JComponent b)
     {
     	if (b == null) return;
-        //b.setMargin(new Insets(0, 2, 0, 3));
-        //b.setBorderPainted(false);
-        //b.setFocusPainted(false);
     	b.setOpaque(false);
     	b.setBorder(new EmptyBorder(2, 2, 2, 2));
     }
@@ -1245,9 +1240,7 @@ public class UIUtilities
     public static void opacityCheck(AbstractButton b)
     {
     	if (b == null) return;
-    	//String laf = UIManager.getSystemLookAndFeelClassName();
     	b.setContentAreaFilled(!isMacOS());
-    	//b.setContentAreaFilled(!(MAC_L_AND_F.equals(laf)));
     }
     
     /**
@@ -1259,7 +1252,6 @@ public class UIUtilities
     {
     	if (area == null) return;
         area.setBorder(BorderFactory.createBevelBorder(BevelBorder.LOWERED));
-        //area.setForeground(STEELBLUE);
         area.setBackground(BACKGROUND);
         area.setOpaque(true);
         if (area instanceof JTextComponent) 

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/omeeditpane/Position.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/omeeditpane/Position.java
@@ -23,13 +23,8 @@
 package org.openmicroscopy.shoola.util.ui.omeeditpane;
 
 
-//Java imports
 import java.io.Serializable;
 import java.util.Comparator;
-
-//Third-party libraries
-
-//Application-internal dependencies
 
 /** 
  * Locates the position of the text.
@@ -39,9 +34,6 @@ import java.util.Comparator;
  * @author	Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
  * 	<a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
  * @version 3.0
- * <small>
- * (<b>Internal version:</b> $Revision: $Date: $)
- * </small>
  * @since OME3.0
  */
 public class Position
@@ -149,7 +141,7 @@ public class Position
 	int length() { return end-start+1; }
 
 	/**
-	 * Controls if the passed object is <,> or = the current one.
+	 * Controls if the passed object is less, greater than or equals to the current one.
 	 * @see Comparator#compare(Object, Object)
 	 */
 	public int compare(Object o1, Object o2)
@@ -189,7 +181,7 @@ public class Position
 	public String toString() { return "["+start+","+end+"]"; }
 
 	/**
-	 * Controls if the passed object is <,> or = the current one.
+	 * Controls if the passed object is less, greater than or equals the current one.
 	 * @see Comparable#compareTo(Object)
 	 */
 	public int compareTo(Position o)

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/slider/OneKnobSlider.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/slider/OneKnobSlider.java
@@ -1,6 +1,4 @@
 /*
- * org.openmicroscopy.shoola.util.ui.slider.OneKnobSlider
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006 University of Dundee. All rights reserved.
  *
@@ -23,13 +21,8 @@
 
 package org.openmicroscopy.shoola.util.ui.slider;
 
-//Java imports
 import javax.swing.ImageIcon;
 import javax.swing.JSlider;
-
-//Third-party libraries
-
-//Application-internal dependencies
 
 /** 
 * OneKnobSlider is an extension of the {@link JSlider}, 
@@ -46,9 +39,6 @@ import javax.swing.JSlider;
 * @author	Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
 * 	<a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
 * @version 3.0
-* <small>
-* (<b>Internal version:</b> $Revision: $Date: $)
-* </small>
 * @since OME2.2
 */
 public class OneKnobSlider
@@ -59,7 +49,7 @@ public class OneKnobSlider
 	public static final String ONE_KNOB_RELEASED_PROPERTY =
 		"oneKnobReleasedProperty";
 	
-	/** Slider UI for new L&F. */
+	/** Slider UI for new Look And Feel. */
 	private OneKnobSliderUI	sliderUI;	
 	
 	/** This is set to <code>true</code> if the slider has tooltipString. */


### PR DESCRIPTION
This is on top of #6 
It fixes the Javadoc
In order to see if some warnings remain, you will need to use Java version > 1.8 (tested with Java 11)
Currently no warnings are returned if Java 1.8 is used
To check run gradle javadoc

The TODO in ``LookupNames`` will be done in another PR
