### PR TITLE
Version 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "java"
     id "application"
-    id "org.openmicroscopy.project" version "5.5.0-m4"
+    id "org.openmicroscopy.project" version "5.5.0-m5"
 }
 
 group = "org.openmicroscopy"
@@ -30,7 +30,7 @@ dependencies {
     implementation("org.apache.httpcomponents:httpclient:4.5.7")
     implementation("org.apache.httpcomponents:httpcomponents-client:4.5.7")
     implementation("org.jfree:jfreechart:1.0.19")
-    implementation("org.openmicroscopy:omero-blitz:5.5.0-m4")
+    implementation("org.openmicroscopy:omero-blitz:5.5.0-m5")
     implementation("org.swinglabs:swingx:1.6.1")
     if (JavaVersion.current().isJava9Compatible()) {
         implementation("javax.activation:activation:1.1.1")

--- a/src/config/container.xml
+++ b/src/config/container.xml
@@ -314,7 +314,6 @@
    * etc.
    * <entry name="SplashScreenLogo">client_splashscreen.png</entry>
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-    <entry name="Version">@OMERO_DISPLAY_VERSION@</entry>
     <entry name="SoftwareName">OMERO.insight</entry>
     <entry name="AboutFile">about.xml</entry>
     <entry name="HelpOnLine">https://help.openmicroscopy.org/</entry>

--- a/src/config/containerImporter.xml
+++ b/src/config/containerImporter.xml
@@ -295,7 +295,6 @@
    * etc.
    * <entry name="SplashScreenLogo">client_splashscreen.png</entry>
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-  <entry name="Version">@OMERO_DISPLAY_VERSION@</entry>
   <entry name="SoftwareName">OMERO.importer</entry>
   <entry name="AboutFile">about.xml</entry>
   <entry name="HelpOnLine">https://help.openmicroscopy.org/</entry>

--- a/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -516,9 +516,6 @@ public class DataServicesFactory
             registry.getLogger().warn(this, "Could not access ConfigService");
         }
 
-        //Upgrade check only if client and server are compatible
-        omeroGateway.isUpgradeRequired(name);
-
         //Post an event to indicate that the user is connected.
         EventBus bus = container.getRegistry().getEventBus();
         bus.post(new ConnectedEvent());

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -37,7 +37,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
@@ -94,7 +93,6 @@ import ome.formats.importer.ImportLibrary;
 import ome.formats.importer.OMEROWrapper;
 import ome.formats.importer.util.ProportionalTimeEstimatorImpl;
 import ome.formats.importer.util.TimeEstimator;
-import ome.system.UpgradeCheck;
 import ome.util.checksum.ChecksumProvider;
 import ome.util.checksum.ChecksumProviderFactory;
 import ome.util.checksum.ChecksumProviderFactoryImpl;
@@ -1411,30 +1409,6 @@ class OMEROGateway
 			throw new DSOutOfServiceException("Cannot retrieve user's data " +
 					printErrorText(e), e);
 		}
-	}
-
-	/**
-	 * Returns <code>true</code> if an upgrade is required, <code>false</code>
-	 * otherwise.
-	 *
-	 * @param name The name of the agent.
-	 * @return See above.
-	 */
-	boolean isUpgradeRequired(String name)
-	{
-	    ResourceBundle bundle = ResourceBundle.getBundle("omero");
-	    String version = bundle.getString("omero.version");
-	    String url = bundle.getString("omero.upgrades.url");
-	    //Strip the "OMERO" part of the string
-	    if (CommonsLangUtils.isBlank(name)) {
-	        name = "insight";
-	    }
-	    if (name.startsWith("OMERO.")) {
-	        name = name.substring("OMERO.".length());
-	    }
-	    UpgradeCheck check = new UpgradeCheck(url, version, name);
-	    check.run();
-	    return check.isUpgradeNeeded();
 	}
 
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
@@ -36,6 +36,7 @@ import javax.swing.Icon;
 import javax.swing.JFrame;
 
 
+import org.openmicroscopy.shoola.Main;
 import org.openmicroscopy.shoola.env.Container;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.config.OMEROInfo;
@@ -153,7 +154,7 @@ class SplashScreenManager
     		view.requestFocusOnField();
     	}
     }
-    
+
     /** 
      * Initializes the view. 
      * 
@@ -163,10 +164,11 @@ class SplashScreenManager
     {
     	if (view != null) return;	
     	Image img = IconManager.getOMEImageIcon();
-    	Object version = container.getRegistry().lookup(LookupNames.VERSION);
-    	String v = "";
-    	if (version != null && version instanceof String)
-    		v = (String) version;
+		String clientVersion = SplashScreenManager.class.getPackage().getImplementationVersion();
+		if (clientVersion == null) {
+			clientVersion = "Unknown";
+		}
+		container.getRegistry().bind(LookupNames.VERSION, clientVersion);
     	OMEROInfo info = 
     		(OMEROInfo) container.getRegistry().lookup(LookupNames.OMERODS);
     	int p = -1;
@@ -175,7 +177,7 @@ class SplashScreenManager
     	boolean configurable = info.isHostNameConfigurable();
 
         boolean serverAvailable = connectToServer();
-    	view = new ScreenLogin(Container.TITLE, splashscreen, img, v, port,
+    	view = new ScreenLogin(Container.TITLE, splashscreen, img, clientVersion, port,
     			host, serverAvailable);
     	view.setEncryptionConfiguration(info.isEncrypted(),
     			info.isEncryptedConfigurable());


### PR DESCRIPTION
Read the version from the manifest
The value not longer needs to be set from the configuration file
To test:
 * Run ``gradle build``
 * Unzip ``build/distributions/omero-insight-5.5.0-SNAPSHOT.zip``
 * go to the created directory
 * Run ``bin/omero-insight``
 * Check that the version is displayed on the splashscreen

When running ``gradle run``, no version should be displayed. In that case, it should be set to ``Unknown``