### PR TITLE
plugin bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation("org.jfree:jfreechart:1.0.19")
     implementation("org.swinglabs:swingx:1.6.1")
 
-    implementation("org.openmicroscopy:omero-blitz:5.5.0-m5") {
+    implementation("org.openmicroscopy:omero-java-gateway:5.5.0-m2") {
         // Conflicts with `net.java.dev.jna`
         exclude group: "com.sun.jna", module: "jna"
         exclude group: "org.springframework"

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation("org.jfree:jfreechart:1.0.19")
     implementation("org.swinglabs:swingx:1.6.1")
 
-    implementation("org.openmicroscopy:omero-java-gateway:5.5.0-m2") {
+    implementation("org.openmicroscopy:omero-java-gateway:5.5.0-m3") {
         // Conflicts with `net.java.dev.jna`
         exclude group: "com.sun.jna", module: "jna"
         exclude group: "org.springframework"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation "org.openmicroscopy:omero-javapackager-plugin:5.5.0-m1"
+    implementation "org.openmicroscopy:omero-javapackager-plugin:5.5.0-m2"
 }
 
 gradlePlugin {


### PR DESCRIPTION
Bump to m2 so that the version of executable is correctly set.

To test run either ``gradle packageApplicationDmg`` or ``gradle packageApplicationExe``
check that the generated distribution has the version ``5.5.0-SNAPSHOT``
a warning/error indicating that the version is "not correct" will be printed in the console but the distribution will be generated
There is no issue if a value like ``5.5.0`` is used

This PR also uses https://github.com/ome/omero-java-gateway instead of omero-blitz.
