### PR TITLE
Travis: osx and linux build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,19 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test -f build/distributions/OMERO.insight-* ; fi
 
 deploy:
-  provider: releases
-  api_key: $GITHUB_OAUTH_TOKEN
-  file_glob: true
-  file: build/distributions/*
-  skip_cleanup: true
-  on:
-    tags: true
+  - provider: releases
+    api_key: $GITHUB_OAUTH_TOKEN
+    file_glob: true
+    file: build/distributions/*
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: "$TRAVIS_OS_NAME = linux"
+  - provider: releases
+    api_key: $GITHUB_OAUTH_TOKEN
+    file_glob: true
+    file: build/packaged/main/*
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: "$TRAVIS_OS_NAME = osx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./gradlew packageApplicationDmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && -n "$TRAVIS_TAG" ]]; then ./gradlew packageImporterApplicationDmg ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then test -f build/packaged/main/bundles/OMERO.insight-* ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./gradlew build ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test -f build/distributions/OMERO.imagej-* ; fi
@@ -42,3 +43,12 @@ deploy:
     on:
       tags: true
       condition: "$TRAVIS_OS_NAME = osx"
+  - provider: releases
+      api_key: $GITHUB_OAUTH_TOKEN
+      file_glob: true
+      script: ./gradlew packageImporterApplicationDmg
+      file: build/packaged/installImporterDist/bundles/*
+      skip_cleanup: true
+      on:
+        tags: true
+        condition: "$TRAVIS_OS_NAME = osx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ deploy:
   - provider: releases
       api_key: $GITHUB_OAUTH_TOKEN
       file_glob: true
-      script: ./gradlew packageImporterApplicationDmg
       file: build/packaged/installImporterDist/bundles/*
       skip_cleanup: true
       on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 os:
   - osx
   - linux
+osx_image: xcode9.3
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -19,7 +20,7 @@ install:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./gradlew packageApplicationDmg ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then test -f build/packaged/main/OMERO.insight-* ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then test -f build/packaged/main/bundles/OMERO.insight-* ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./gradlew build ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test -f build/distributions/OMERO.imagej-* ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test -f build/distributions/OMERO.insight-* ; fi
@@ -36,7 +37,7 @@ deploy:
   - provider: releases
     api_key: $GITHUB_OAUTH_TOKEN
     file_glob: true
-    file: build/packaged/main/*
+    file: build/packaged/main/bundles/*
     skip_cleanup: true
     on:
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,10 @@ install:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./gradlew packageApplicationDmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then test -f build/packaged/main/OMERO.insight-* ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./gradlew build ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test -f build/distributions/OMERO.imagej-* ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test -f build/distributions/OMERO.insight-* ; fi
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: java
+os:
+  - osx
+  - linux
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -7,11 +10,16 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gradle  ; fi
+
 install:
   - DIR=$PWD; (cd /tmp; gradle wrapper --gradle-version=5.2.1; mv .gradle gradle gradlew $DIR)
 
 script:
-  - ./gradlew build
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./gradlew packageApplicationDmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./gradlew build ; fi
 
 deploy:
   provider: releases


### PR DESCRIPTION
Run ``gradle build on linux`` and ``gradle packageApplicationDmg`` on mac

* insight dmg will push to GH when a tag is set
* importer dmg will be built and pushed to GH when a tag is set

This has been tested using merge build of this PR and #22 https://github.com/jburel/omero-insight/releases/tag/v5.5.0-m14
* Check that travis is green
* Download the dmg and check that it can start