### PR TITLE
Silently strip http(s):// from the server name

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
@@ -33,6 +33,8 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -596,15 +598,15 @@ public class ServerEditor
 	 * Extracts the server name if an URL has
 	 * been entered.
 	 * @param s The provided 'server name'
-	 * @return The sanitized server name
+	 * @return The host name
 	 */
 	private String checkServerName(String s) {
-		s = s.trim().toLowerCase();
-		s = s.replaceAll("^https?://", "");
-		if (s.indexOf('/') > 0) {
-			s = s.substring(0, s.indexOf('/'));
+		try {
+			URL url = new URL(s);
+			return url.getHost();
+		} catch (MalformedURLException e) {
+			return s;
 		}
-		return s;
 	}
 
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
@@ -587,12 +587,26 @@ public class ServerEditor
 		if (row == -1) return null;
 		String v = (String) table.getValueAt(row, 1);
 		if (v == null) return null;
-		v = v.replaceAll("^https?://", "");
-		String trim = v.trim();
+		String trim = checkServerName(v);
 		if (trim.length() == 0) return null;
 		return trim;
 	}
-	
+
+	/**
+	 * Extracts the server name if an URL has
+	 * been entered.
+	 * @param s The provided 'server name'
+	 * @return The sanitized server name
+	 */
+	private String checkServerName(String s) {
+		s = s.trim();
+		s = s.replaceAll("^https?://", "");
+		if (s.indexOf('/') > 0) {
+			s = s.substring(0, s.indexOf('/'));
+		}
+		return s;
+	}
+
 	/**
 	 * Returns the value of the selected port.
 	 * 
@@ -670,9 +684,8 @@ public class ServerEditor
 		String v;
 		for (int i = 0; i < table.getRowCount(); i++) {
 			v = (String) table.getValueAt(i, 1);
-			v = v.replaceAll("^https?://", "");
 			if (v != null && v.trim().length() > 0)
-				l.put(v, (String) table.getValueAt(i, 2)); 
+				l.put(checkServerName(v), (String) table.getValueAt(i, 2));
 		}
 			
 		if (activeServer != null && l.get(activeServer) == null) 

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
@@ -599,7 +599,7 @@ public class ServerEditor
 	 * @return The sanitized server name
 	 */
 	private String checkServerName(String s) {
-		s = s.trim();
+		s = s.trim().toLowerCase();
 		s = s.replaceAll("^https?://", "");
 		if (s.indexOf('/') > 0) {
 			s = s.substring(0, s.indexOf('/'));

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
@@ -601,6 +601,7 @@ public class ServerEditor
 	 * @return The host name
 	 */
 	private String checkServerName(String s) {
+		s = s.trim();
 		try {
 			URL url = new URL(s);
 			return url.getHost();

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.login.ServerEditor 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2019 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -485,7 +485,7 @@ public class ServerEditor
 	}
 	
 	/**
-	 * Enables or not the {@link #finishButton}.
+	 * Enables or not the finishButton.
 	 * 
 	 * @param row			The selected row.
 	 * @param previousRow 	The previously selected row.
@@ -587,6 +587,7 @@ public class ServerEditor
 		if (row == -1) return null;
 		String v = (String) table.getValueAt(row, 1);
 		if (v == null) return null;
+		v = v.replaceAll("^https?://", "");
 		String trim = v.trim();
 		if (trim.length() == 0) return null;
 		return trim;
@@ -669,6 +670,7 @@ public class ServerEditor
 		String v;
 		for (int i = 0; i < table.getRowCount(); i++) {
 			v = (String) table.getValueAt(i, 1);
+			v = v.replaceAll("^https?://", "");
 			if (v != null && v.trim().length() > 0)
 				l.put(v, (String) table.getValueAt(i, 2)); 
 		}

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
@@ -602,6 +602,7 @@ public class ServerEditor
 	 */
 	private String checkServerName(String s) {
 		s = s.trim();
+		s = s.replaceAll("/+$", "");
 		try {
 			URL url = new URL(s);
 			return url.getHost();


### PR DESCRIPTION
Many people accidentaly enter the full OMERO.web URL as server name in Insight. This PR simply strips the `^https?://` part.

**Test:**
Add a new Server. Use `https://demo.openmicroscopy.org` as server name. You should then be able to simply connect to `demo.openmicroscopy.org`.