### PR TITLE
Prevent stackoverflow exception

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/util/ui/treetable/OMETreeTable.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/treetable/OMETreeTable.java
@@ -318,10 +318,13 @@ public class OMETreeTable
 	 */
 	public void expandPath(TreePath path)
 	{
-		super.expandPath(path);
-		if (path == null) return;
+		if (path == null)
+			return;
 		OMETreeNode node = (OMETreeNode) path.getLastPathComponent();
-		if (node != null) node.setExpanded(true);
+		if (node != null && !node.isExpanded()) {
+			node.setExpanded(true);
+			super.expandPath(path);
+		}
 	}
 	
 	/**


### PR DESCRIPTION
This should fix the StackOverflowException you get when double clicking the comment field without an ROI being selected first, e. g. https://www.openmicroscopy.org/qa2/qa/feedback/27612/ 
I'm not quite sure yet, if this change has any other unwanted side effects.

Edit: Listing it for review now. Haven't noticed any side effects.
