### PR TITLE
Deprecate SERVER_5_4_8_OR_LATER.

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
@@ -115,8 +115,8 @@ public class LookupNames
 
     /** 
      * Field to check if the server version is 5.4.8 or later.
-     * TODO: Can be removed for 5.5.0 release
      * */
+    @Deprecated
     public static final String SERVER_5_4_8_OR_LATER = "5.4.8 or later";
     
     /** Maximum plane width for non pyramid images **/

--- a/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -490,7 +490,6 @@ public class DataServicesFactory
         cred.setEncryption(uc.isEncrypted());
         ExperimenterData exp = omeroGateway.connect(cred);
 
-
 		//check client server version
 		compatible = true;
         //Register into log file.
@@ -504,9 +503,6 @@ public class DataServicesFactory
         //Check if client and server are compatible.
         String version = omeroGateway.getServerVersion();
 
-        // TODO: Can be removed for >= 5.5.0 release
-        container.getRegistry().bind(LookupNames.SERVER_5_4_8_OR_LATER, VersionCompare.compare(version, "5.4.8") >= 0);
-        
         IConfigPrx cs = omeroGateway.getGateway().getConfigService(new SecurityContext(exp.getGroupId()));
         try {
             String val = cs.getConfigValue("omero.pixeldata.max_plane_width");

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -335,16 +335,8 @@ public class ThumbnailLoader extends BatchCallTree {
                 store.setRenderingDefId(rndDefId);
         }
 
-        if ((boolean) context.lookup(LookupNames.SERVER_5_4_8_OR_LATER)) {
-            // If the client is connecting to a server with version 5.4.8 or greater, use the thumbnail
-            // loading function that doesn't return a clock.
-            // TODO: Can be removed for >= 5.5.0 release
-            return store.getThumbnailWithoutDefault(omero.rtypes.rint(sizeX),
-                    omero.rtypes.rint(sizeY));
-        } else {
-            return store.getThumbnail(omero.rtypes.rint(sizeX),
-                    omero.rtypes.rint(sizeY));
-        }
+        return store.getThumbnailWithoutDefault(omero.rtypes.rint(sizeX),
+                omero.rtypes.rint(sizeY));
     }
 
     /**


### PR DESCRIPTION
Removes from Insight the special thumbnail handling for OMERO.server <5.4.8.