### PR TITLE
Bump to 5.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+5.5.3 (July 2019)
+-----------------
+
+- Fix SSL cipher issue to allow Insight to be used from Fedora 30
+- Fix stack overflow exception
+- Bump to omero-gateway-java 5.5.3
+
 5.5.2 (June 2019)
 -----------------
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.openmicroscopy"
-version = "5.5.3"
+version = "5.5.3-SNAPSHOT"
 
 repositories {
     mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.openmicroscopy"
-version = "5.5.3-SNAPSHOT"
+version = "5.5.3"
 
 repositories {
     mavenLocal()
@@ -43,7 +43,7 @@ dependencies {
 
     implementation("net.sf.ehcache:ehcache-core:2.6.11")
 
-    implementation("org.openmicroscopy:omero-gateway:5.5.2") {
+    implementation("org.openmicroscopy:omero-gateway:5.5.3") {
         // Conflicts with `net.java.dev.jna`
         exclude group: "com.sun.jna", module: "jna"
     }


### PR DESCRIPTION
Follows on from gh-54 by bumping GW _further_. Version bump for omero-insight and changelog are also included.