### PR TITLE
Import ui fixes

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/ImagesImporter.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/ImagesImporter.java
@@ -136,7 +136,6 @@ public class ImagesImporter
         msg.print(exc);
         registry.getLogger().error(this, msg);
         registry.getUserNotifier().notifyError("Data Import Failure", s, exc);
-		viewer.cancelImport(loaderID);
 	}
 
     /**

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/TagsLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/TagsLoader.java
@@ -113,7 +113,6 @@ public class TagsLoader
         registry.getLogger().error(this, msg);
         registry.getUserNotifier().notifyError("Data Retrieval Failure", 
                                                s, exc);
-		viewer.cancel();
 	}
 	
 }

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -1022,7 +1022,16 @@ public class FileImportComponent
      */
     @Override
     public long getExperimenterID() { return importable.getUser().getId(); }
-	
+
+	@Override
+	public Collection<? extends FileImportComponentI> getChildren() {
+		try {
+			return this.components.values();
+		} catch( Throwable t) {
+			return Collections.emptyList();
+		}
+	}
+
 	/* (non-Javadoc)
      * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getImportErrorObject()
      */
@@ -1089,22 +1098,6 @@ public class FileImportComponent
         }
 		return false;
 	}
-	
-    @Override
-    public int cancelled() {
-        int c = 0;
-        if (components != null) {
-            Collection<FileImportComponent> values = components.values();
-            synchronized (components) {
-                Iterator<FileImportComponent> i = values.iterator();
-                while (i.hasNext()) {
-                    if (i.next().isCancelled())
-                        c++;
-                }
-            }
-        }
-        return c;
-    }
 
 	/* (non-Javadoc)
      * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#hasImportToCancel()

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
@@ -174,6 +174,8 @@ public interface FileImportComponentI {
      */
     public abstract long getExperimenterID();
 
+    public abstract Collection<? extends FileImportComponentI> getChildren();
+
     /**
      * Returns the import error object.
      * 
@@ -205,13 +207,6 @@ public interface FileImportComponentI {
      */
     public abstract boolean isCancelled();
 
-    /**
-     * Returns the number of cancelled imports
-     * 
-     * @return See above.
-     */
-    public int cancelled();
-    
     /**
      * Returns <code>true</code> if the component has imports to cancel,
      * <code>false</code> otherwise.

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -174,6 +174,15 @@ public class LightFileImportComponent implements PropertyChangeListener,
         }
     }
 
+    @Override
+    public Collection<? extends FileImportComponentI> getChildren() {
+        try {
+            return this.components.values();
+        } catch( Throwable t) {
+            return Collections.emptyList();
+        }
+    }
+
     /** Initializes the components. */
     private void initComponents() {
         status = new Status(importable.getFile());
@@ -591,24 +600,6 @@ public class LightFileImportComponent implements PropertyChangeListener,
             }
         }
         return false;
-    }
-    
-    @Override
-    public int cancelled() {
-        int c = 0;
-        if (components != null && !components.isEmpty()) {
-            Collection<LightFileImportComponent> values = components.values();
-            synchronized (components) {
-                Iterator<LightFileImportComponent> i = values.iterator();
-                while (i.hasNext()) {
-                    if (i.next().isCancelled())
-                        c++;
-                }
-            }
-        } else if (isCancelled()) {
-            c++;
-        }
-        return c;
     }
 
     /*

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/Importer.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/Importer.java
@@ -169,16 +169,6 @@ public interface Importer
      */
     void removeImportElement(Object element);
 
-    /** Cancels any on-going import. */
-    public void cancel();
-
-    /**
-     * Cancels the loading of images.
-     * 
-     * @param id The identifier of the import element.
-     */
-    public void cancelImport(int id);
-
     /**
      * Returns <code>true</code> if errors to send, <code>false</code>
      * otherwise.
@@ -221,14 +211,6 @@ public interface Importer
      * @param fc The file to upload or <code>null</code>.
      */
     public void retryUpload(FileImportComponentI fc);
-
-    /**
-     * Returns <code>true</code> if it is the last file to import,
-     * <code>false</code> otherwise.
-     * 
-     * @return See above.
-     */
-    boolean isLastImport();
 
     /**
      * Sets the containers.

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
@@ -475,26 +475,6 @@ class ImporterComponent
 
 	/** 
 	 * Implemented as specified by the {@link Importer} interface.
-	 * @see Importer#cancel()
-	 */
-	public void cancel()
-	{
-		if (model.getState() != DISCARDED)
-			model.cancel();
-	}
-
-	/** 
-	 * Implemented as specified by the {@link Importer} interface.
-	 * @see Importer#cancelImport(int)
-	 */
-	public void cancelImport(int id)
-	{
-		//if (model.getState() != DISCARDED)
-		//	model.cancel(id);
-	}
-	
-	/** 
-	 * Implemented as specified by the {@link Importer} interface.
 	 * @see Importer#hasFailuresToSend()
 	 */
 	public boolean hasFailuresToSend()
@@ -566,17 +546,6 @@ class ImporterComponent
 		}
 		object.reUpload(list);
 		importData(object);
-	}
-
-	/** 
-	 * Implemented as specified by the {@link Importer} interface.
-	 * @see Importer#isLastImport()
-	 */
-	public boolean isLastImport()
-	{
-		ImporterUIElement element = view.getSelectedPane();
-		if (element == null) return false;
-		return element.isLastImport();
 	}
 
 	/** 

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -297,7 +297,6 @@ class ImporterModel
 	 */
 	void discard()
 	{
-		cancel();
 		if (loaders.size() > 0) {
 			Iterator<ImagesImporter> i = loaders.values().iterator();
 			while (i.hasNext()) {
@@ -306,15 +305,6 @@ class ImporterModel
 			loaders.clear();
 		}
 		state = Importer.DISCARDED;
-	}
-
-	/**
-	 * Sets the object in the {@link Importer#READY} state.
-	 * Any ongoing data loading will be cancelled.
-	 */
-	void cancel()
-	{
-		//state = Importer.READY;
 	}
 
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
@@ -268,10 +268,9 @@ class ImporterUI extends TopWindow
             p.add(Box.createHorizontalStrut(5));
         }
         b = new JButton(controller.getAction(ImporterControl.CANCEL_BUTTON));
-        if (visible) {
-            p.add(b);
-            p.add(Box.createHorizontalStrut(5));
-        }
+        p.add(b);
+        p.add(Box.createHorizontalStrut(5));
+
         if (!model.isMaster()) {
             p.add(new JButton(controller.getAction(
                     ImporterControl.CLOSE_BUTTON)));

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
@@ -256,7 +256,7 @@ class ImporterUI extends TopWindow
     {
         JPanel p = new JPanel();
         Boolean offline = (Boolean) ImporterAgent.getRegistry().lookup(LookupNames.OFFLINE_IMPORT_ENABLED);
-        boolean visible = offline != null && offline.booleanValue();
+        boolean visible = offline == null || !offline.booleanValue();
         JButton b = new JButton(controller.getAction(ImporterControl.RETRY_BUTTON));
         if (visible) {
             p.add(b);
@@ -268,8 +268,10 @@ class ImporterUI extends TopWindow
             p.add(Box.createHorizontalStrut(5));
         }
         b = new JButton(controller.getAction(ImporterControl.CANCEL_BUTTON));
-        p.add(b);
-        p.add(Box.createHorizontalStrut(5));
+		if (visible) {
+			p.add(b);
+			p.add(Box.createHorizontalStrut(5));
+		}
 
         if (!model.isMaster()) {
             p.add(new JButton(controller.getAction(

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementDetailed.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementDetailed.java
@@ -245,6 +245,7 @@ class ImporterUIElementDetailed
 
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
+		super.propertyChange(evt);
         String name = evt.getPropertyName();
         if (FileImportComponentI.BROWSE_PROPERTY.equals(name)) {
             List<Object> refNodes = object.getRefNodes();
@@ -252,13 +253,6 @@ class ImporterUIElementDetailed
             if (refNodes != null && refNodes.size() > 0)
                 node = refNodes.get(0);
             browse(evt.getNewValue(), node);
-        } else if (
-            FileImportComponentI.IMPORT_FILES_NUMBER_PROPERTY.equals(
-                    name)) {
-            //-1 to remove the entry for the folder.
-            Integer v = (Integer) evt.getNewValue()-1;
-            totalToImport += v;
-            setNumberOfImport();
         } else if (FileImportComponentI.LOAD_LOGFILEPROPERTY.equals(
                 name)) {
             FileImportComponentI fc = (FileImportComponentI)
@@ -286,10 +280,6 @@ class ImporterUIElementDetailed
         } else if (FileImportComponentI.RETRY_PROPERTY.equals(name)) {
             controller.retryUpload(
                     (FileImportComponent) evt.getNewValue());
-        } else if (
-            FileImportComponentI.CANCEL_IMPORT_PROPERTY.equals(name)) {
-            controller.cancel(
-                    (FileImportComponentI) evt.getNewValue());
         }
     }
 

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -205,7 +205,6 @@ class ImporterUIElementLight extends ImporterUIElement {
     }
 
     private void updateDisplay() {
-
         int complete = 0;
         int uploaded = 0;
         for (int i = 1; i < 7; i++) {
@@ -278,11 +277,12 @@ class ImporterUIElementLight extends ImporterUIElement {
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
         String name = evt.getPropertyName();
+        boolean needsUpdate = false;
         if (FileImportComponentI.IMPORT_FILES_NUMBER_PROPERTY.equals(name)) {
             // -1 to remove the entry for the folder.
             Integer v = (Integer) evt.getNewValue() - 1;
             totalToImport += v;
-            setNumberOfImport();
+            needsUpdate = true;
         } else if (FileImportComponentI.CANCEL_IMPORT_PROPERTY.equals(name)) {
             controller.cancel((FileImportComponentI) evt.getNewValue());
         } else if (Status.STEP_PROPERTY.equals(name)) {
@@ -292,19 +292,17 @@ class ImporterUIElementLight extends ImporterUIElement {
             importStatus.put(id, step);
             if (isScanning != null && isScanning)
                 isScanning = false;
+            needsUpdate = true;
         }
         else if (Status.SCANNING_PROPERTY.equals(name)) {
-            if (isScanning == null)
+            if (isScanning == null) {
                 isScanning = true;
-        }
-        
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                updateDisplay();
+                needsUpdate = true;
             }
-        });
-        
+        }
+
+        if (needsUpdate)
+            updateDisplay();
     }
 
 }

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -27,8 +27,10 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.beans.PropertyChangeEvent;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -57,8 +59,6 @@ import org.openmicroscopy.shoola.util.ui.UIUtilities;
  *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
  */
 class ImporterUIElementLight extends ImporterUIElement {
-
-    private Map<Integer, Integer> importStatus = new ConcurrentHashMap<Integer, Integer>();
 
     private JProgressBar upload = new JProgressBar(SwingConstants.HORIZONTAL);
     private JProgressBar processed = new JProgressBar(SwingConstants.HORIZONTAL);
@@ -204,67 +204,70 @@ class ImporterUIElementLight extends ImporterUIElement {
         add(info, BorderLayout.CENTER);
     }
 
-    private void updateDisplay() {
-        int complete = 0;
-        int uploaded = 0;
-        for (int i = 1; i < 7; i++) {
-            int c = 0;
-            for (int step : importStatus.values()) {
-                if (i == step)
-                    c++;
-            }
-            uploaded += c;
-            if (i == 6)
-                complete = c;
-        }
+    // Prevent GUI updates queueing up and freezing
+    AtomicBoolean updateRequest = new AtomicBoolean(false);
 
-        if (isScanning != null) {
-            if (isScanning) {
-                scanningBusy.setBusy(true);
-            }
-            else {
-                scanningBusy.setBusy(false);
-                scanningBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
-            }
+    @Override
+    void setNumberOfImport() {
+        if (!updateRequest.get()) {
+            SwingUtilities.invokeLater(new Runnable() {
+                @Override
+                public void run() {
+                    ImporterUIElementLight.super.setNumberOfImport();
+                    updateRequest.set(true);
+                    updateGUI();
+                }
+            });
         }
-        
-        
-        int cancelled = super.cancelled();
-        
-        upload.setValue(uploaded);
+    }
+
+    private void updateGUI() {
+        updateRequest.set(false);
+
+        upload.setValue(super.countUploaded);
         upload.setMaximum(super.totalToImport);
-        uploadBusy.setText(+uploaded + "/" + super.totalToImport);
-        // if there are many imports to cancel this might take a while; in that
-        // case until all cancellations went through there might have been another
-        // upload happened so this could sum up to something > super.totalToImport
+        uploadBusy.setText(+super.countUploaded + "/" + super.totalToImport);
+
+        processed.setValue(super.countImported);
+        processed.setMaximum(super.countUploaded);
+        processedBusy.setText(super.countImported + "/" + super.countUploaded);
+
         if (super.isDone()) {
             uploadBusy.setBusy(false);
             uploadBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
-        }  else {
-            uploadBusy.setBusy(true);
-        }
-        
-        processed.setValue(complete);
-        processed.setMaximum(uploaded);
-        processedBusy.setText(complete + "/" + uploaded);
-        if (super.isDone()) {
             processedBusy.setBusy(false);
             processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
+
+            int cancelled = super.cancelled();
+            if (cancelled > 0) {
+                if (!this.cancelledLabel.isVisible())
+                    this.cancelledLabel.setVisible(true);
+                if (!this.cancelled.getText().equals(""+cancelled))
+                    this.cancelled.setText(""+cancelled);
+                if (!this.cancelled.isVisible())
+                    this.cancelled.setVisible(true);
+            }
         } else {
-            processedBusy.setBusy(true);
+            if (!uploadBusy.isBusy())
+                uploadBusy.setBusy(true);
+            if (!processedBusy.isBusy())
+                processedBusy.setBusy(true);
         }
-        
-        errors.setText("" + super.countFailure);
-        
-        if (cancelled > 0) {
-            this.cancelledLabel.setVisible(true);
-            this.cancelled.setText(""+cancelled);
-            this.cancelled.setVisible(true);
+
+        if (scanningBusy.isBusy() && super.countUploaded > 0) {
+            scanningBusy.setBusy(false);
+            scanningBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
         }
-        
+
         if (super.countFailure > 0) {
-            super.filterButton.setEnabled(true);
+            if (!super.filterButton.isEnabled())
+                super.filterButton.setEnabled(true);
+            if (!errors.getText().equals("" + super.countFailure))
+                errors.setText("" + super.countFailure);
         }
+
+        if (updateRequest.get())
+            updateGUI();
     }
 
     @Override
@@ -275,34 +278,10 @@ class ImporterUIElementLight extends ImporterUIElement {
     }
 
     @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        String name = evt.getPropertyName();
-        boolean needsUpdate = false;
-        if (FileImportComponentI.IMPORT_FILES_NUMBER_PROPERTY.equals(name)) {
-            // -1 to remove the entry for the folder.
-            Integer v = (Integer) evt.getNewValue() - 1;
-            totalToImport += v;
-            needsUpdate = true;
-        } else if (FileImportComponentI.CANCEL_IMPORT_PROPERTY.equals(name)) {
-            controller.cancel((FileImportComponentI) evt.getNewValue());
-        } else if (Status.STEP_PROPERTY.equals(name)) {
-            String[] tmp = ((String) evt.getNewValue()).split("_");
-            int id = Integer.parseInt(tmp[0]);
-            int step = Integer.parseInt(tmp[1]);
-            importStatus.put(id, step);
-            if (isScanning != null && isScanning)
-                isScanning = false;
-            needsUpdate = true;
+    public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+        super.propertyChange(propertyChangeEvent);
+        if (isScanning == null) {
+            scanningBusy.setBusy(true);
         }
-        else if (Status.SCANNING_PROPERTY.equals(name)) {
-            if (isScanning == null) {
-                isScanning = true;
-                needsUpdate = true;
-            }
-        }
-
-        if (needsUpdate)
-            updateDisplay();
     }
-
 }


### PR DESCRIPTION
Fixes the importer UI freeze when importing many images and enable the cancel, retry, submit buttons again. Together with https://github.com/ome/omero-gateway-java/pull/16 this should fix the issue https://github.com/ome/omero-insight/issues/57 .

**TEST**
Import > 4000 images on Windows. The issue affected all OS, but on Windows it was especially bad.
Should also be tested with just a couple of images, including multi-file images (eg. *.dv + *.log) to check if the 'normal' importer UI still works as expected.
