### PR TITLE
Add travis_retry to dmg steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ install:
   - DIR=$PWD; (cd /tmp; gradle wrapper --gradle-version=5.2.1; mv .gradle gradle gradlew $DIR)
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./gradlew packageApplicationDmg ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && -n "$TRAVIS_TAG" ]]; then ./gradlew packageImporterApplicationDmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry ./gradlew packageApplicationDmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && -n "$TRAVIS_TAG" ]]; then travis_retry ./gradlew packageImporterApplicationDmg ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then test -f build/packaged/main/bundles/OMERO.insight-* ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./gradlew build ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test -f build/distributions/OMERO.imagej-* ; fi


### PR DESCRIPTION
Attempt to correct https://github.com/ome/omero-insight/pull/61#issuecomment-518988457

> This is a random error. Travis needs to be restarted

cf:

```
Exception in thread "main" com.sun.javafx.tools.packager.PackagerException: Error: Bundler "DMG Installer" (dmg) failed to produce a bundle.
	at com.sun.javafx.tools.packager.PackagerLib.generateNativeBundles(PackagerLib.java:354)
	at com.sun.javafx.tools.packager.PackagerLib.generateDeploymentPackages(PackagerLib.java:319)
	at com.sun.javafx.tools.packager.Main.main(Main.java:476)
```