### PR TITLE
Bugfix: Cut and paste

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerModel.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerModel.java
@@ -573,8 +573,7 @@ class TreeViewerModel
 			currentLoader = new DataObjectUpdater(component,ctx,  map,
 					DataObjectUpdater.COPY_AND_PASTE);
 		else if (copyIndex == TreeViewer.CUT_AND_PASTE) {
-			Map toRemove = buildCutMap(nodesToCopy);
-			currentLoader = new DataObjectUpdater(component, ctx, map, toRemove,
+			currentLoader = new DataObjectUpdater(component, ctx, map, null,
 					DataObjectUpdater.CUT_AND_PASTE);
 		}
 		currentLoader.load();


### PR DESCRIPTION
Bugfix for: https://www.openmicroscopy.org/qa2/qa/feedback/27791/ 
The 'cut' already happenend when then 'cut and paste' action is performed, so it tried to delete a link which didn't exist any longer. The logic/sequence of these actions must have changed at some point in the past.

# Test
Cut and paste a few images in Insight from one dataset to another.