### PR TITLE
fat jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,9 @@ dependencies {
     implementation("info.clearthought:table-layout:4.3.0")
     implementation("insight:JHotDraw:7.0.9")
     implementation("net.imagej:ij:1.48s")
-    implementation("net.java.dev.jna:jna-platform:5.3.0")
+    implementation("net.java.dev.jna:jna-platform:4.5.2") {
+        exclude group: "com.sun.jna", module: "jna"
+    }
     implementation("org.apache.poi:poi:4.0.1")
     implementation("org.apache.commons:commons-collections4:4.3")
     implementation("org.apache.httpcomponents:httpmime:4.5.7")

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,6 +11,7 @@ repositories {
 
 dependencies {
     implementation "org.openmicroscopy:omero-javapackager-plugin:5.5.1"
+    implementation "com.github.jengelman.gradle.plugins:shadow:5.1.0"
 }
 
 gradlePlugin {

--- a/buildSrc/src/main/groovy/org/openmicroscopy/DistributePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/openmicroscopy/DistributePlugin.groovy
@@ -43,13 +43,13 @@ class DistributePlugin implements Plugin<Project> {
 
     public static final String DISTRIBUTION_NAME_IMAGEJ = "OMERO.imagej"
 
-    public static final String DISTRIBUTION_NAME_FIJI = "OMERO.fiji"
+    public static final String DISTRIBUTION_NAME_FIJI = DISTRIBUTION_NAME_IMAGEJ//"OMERO.fiji"
 
     public static final String DISTRIBUTION_IMPORTER = "importer"
 
     public static final String DISTRIBUTION_IMAGEJ = "imagej"
 
-    public static final String DISTRIBUTION_FIJI = "fiji"
+    public static final String DISTRIBUTION_FIJI = DISTRIBUTION_IMAGEJ//"fiji"
 
     public static final String TASK_IMPORTER_START_SCRIPTS = "importerStartScripts"
 
@@ -75,7 +75,7 @@ class DistributePlugin implements Plugin<Project> {
 
         configureMainDistribution(distributionContainer, configSpec)
         createImporterDistribution(distributionContainer, configSpec)
-        createImageJPluginDistribution(distributionContainer, configSpec)
+        //createImageJPluginDistribution(distributionContainer, configSpec)
         createImageJFatJarPluginDistribution(distributionContainer, configSpec)
 
         // Skip tar tasks

--- a/buildSrc/src/main/groovy/org/openmicroscopy/DistributePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/openmicroscopy/DistributePlugin.groovy
@@ -43,9 +43,13 @@ class DistributePlugin implements Plugin<Project> {
 
     public static final String DISTRIBUTION_NAME_IMAGEJ = "OMERO.imagej"
 
+    public static final String DISTRIBUTION_NAME_FIJI = "OMERO.fiji"
+
     public static final String DISTRIBUTION_IMPORTER = "importer"
 
     public static final String DISTRIBUTION_IMAGEJ = "imagej"
+
+    public static final String DISTRIBUTION_FIJI = "fiji"
 
     public static final String TASK_IMPORTER_START_SCRIPTS = "importerStartScripts"
 
@@ -72,6 +76,7 @@ class DistributePlugin implements Plugin<Project> {
         configureMainDistribution(distributionContainer, configSpec)
         createImporterDistribution(distributionContainer, configSpec)
         createImageJPluginDistribution(distributionContainer, configSpec)
+        createImageJFatJarPluginDistribution(distributionContainer, configSpec)
 
         // Skip tar tasks
         project.tasks.withType(Tar).configureEach {
@@ -134,6 +139,23 @@ class DistributePlugin implements Plugin<Project> {
 
             CopySpec childSpec = project.copySpec()
             childSpec.with(libChildSpec)
+            childSpec.with(mainSpec)
+
+            imageJ.contents.with(childSpec)
+        }
+    }
+
+    private void createImageJFatJarPluginDistribution(DistributionContainer distributionContainer, CopySpec configSpec) {
+        // Create and configure imageJ distribution
+        distributionContainer.create(DISTRIBUTION_FIJI) { Distribution imageJ ->
+            imageJ.baseName = DISTRIBUTION_NAME_FIJI
+            imageJ.contents.with(configSpec)
+
+            CopySpec mainSpec = project.copySpec()
+            mainSpec.into("")
+            mainSpec.from(project.tasks.named(InsightBasePlugin.TASK_OMERO_IMAGEJ_FAT_JAR))
+
+            CopySpec childSpec = project.copySpec()
             childSpec.with(mainSpec)
 
             imageJ.contents.with(childSpec)

--- a/buildSrc/src/main/groovy/org/openmicroscopy/DistributePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/openmicroscopy/DistributePlugin.groovy
@@ -43,13 +43,9 @@ class DistributePlugin implements Plugin<Project> {
 
     public static final String DISTRIBUTION_NAME_IMAGEJ = "OMERO.imagej"
 
-    public static final String DISTRIBUTION_NAME_FIJI = DISTRIBUTION_NAME_IMAGEJ//"OMERO.fiji"
-
     public static final String DISTRIBUTION_IMPORTER = "importer"
 
     public static final String DISTRIBUTION_IMAGEJ = "imagej"
-
-    public static final String DISTRIBUTION_FIJI = DISTRIBUTION_IMAGEJ//"fiji"
 
     public static final String TASK_IMPORTER_START_SCRIPTS = "importerStartScripts"
 
@@ -106,7 +102,7 @@ class DistributePlugin implements Plugin<Project> {
     }
 
     private void createImporterDistribution(DistributionContainer distributionContainer, CopySpec configSpec) {
-        // Create and configure imageJ distribution
+        // Create and configure importer distribution
         distributionContainer.create(DISTRIBUTION_IMPORTER) { Distribution importer ->
             importer.baseName = DISTRIBUTION_NAME_IMPORTER
             importer.contents.with(configSpec)
@@ -125,30 +121,10 @@ class DistributePlugin implements Plugin<Project> {
         }
     }
 
-    private void createImageJPluginDistribution(DistributionContainer distributionContainer, CopySpec configSpec) {
+    private void createImageJFatJarPluginDistribution(DistributionContainer distributionContainer, CopySpec configSpec) {
         // Create and configure imageJ distribution
         distributionContainer.create(DISTRIBUTION_IMAGEJ) { Distribution imageJ ->
             imageJ.baseName = DISTRIBUTION_NAME_IMAGEJ
-            imageJ.contents.with(configSpec)
-
-            CopySpec libChildSpec = createLibSpec(null)
-
-            CopySpec mainSpec = project.copySpec()
-            mainSpec.into("")
-            mainSpec.from(project.tasks.named(InsightBasePlugin.TASK_OMERO_IMAGEJ_JAR))
-
-            CopySpec childSpec = project.copySpec()
-            childSpec.with(libChildSpec)
-            childSpec.with(mainSpec)
-
-            imageJ.contents.with(childSpec)
-        }
-    }
-
-    private void createImageJFatJarPluginDistribution(DistributionContainer distributionContainer, CopySpec configSpec) {
-        // Create and configure imageJ distribution
-        distributionContainer.create(DISTRIBUTION_FIJI) { Distribution imageJ ->
-            imageJ.baseName = DISTRIBUTION_NAME_FIJI
             imageJ.contents.with(configSpec)
 
             CopySpec mainSpec = project.copySpec()

--- a/buildSrc/src/main/groovy/org/openmicroscopy/InsightBasePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/openmicroscopy/InsightBasePlugin.groovy
@@ -123,7 +123,7 @@ class InsightBasePlugin implements Plugin<Project> {
             }
         })
     }
-    
+
     private TaskProvider<ShadowJar> addCreateImageJFatJar() {
         JavaPluginConvention convention = project.convention.getPlugin(JavaPluginConvention)
 
@@ -180,7 +180,7 @@ class InsightBasePlugin implements Plugin<Project> {
         }
     }
 
-    private Action<? extends Task> addManifest(String mainClass) {
+    private Action<? extends Task> addManifest(String mainClass, String classPathDir = "") {
 
         return new Action<Jar>() {
             @Override

--- a/buildSrc/src/main/groovy/org/openmicroscopy/InsightBasePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/openmicroscopy/InsightBasePlugin.groovy
@@ -66,7 +66,6 @@ class InsightBasePlugin implements Plugin<Project> {
 
         configureJarTask()
         addProcessConfigs()
-        //addCreateImageJJar()
         addCreateImageJFatJar()
     }
 
@@ -99,29 +98,6 @@ class InsightBasePlugin implements Plugin<Project> {
         }
 
         processConfigs
-    }
-
-    private TaskProvider<Jar> addCreateImageJJar() {
-        JavaPluginConvention javaPluginConvention =
-                project.convention.getPlugin(JavaPluginConvention)
-
-        SourceSet main =
-                javaPluginConvention.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-
-        project.tasks.register(TASK_OMERO_IMAGEJ_JAR, Jar, new Action<Jar>() {
-            @Override
-            void execute(Jar jar) {
-                // This might not be the best way to ensure a parity of names
-                Jar jarTask = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME) as Jar
-
-                jar.archiveBaseName.set(createImageJName(jarTask, "ij"))
-                jar.setDescription("Assembles a jar for use with ImageJ")
-                jar.setGroup(GROUP_BUILD)
-                jar.dependsOn(project.tasks.getByName(JavaPlugin.CLASSES_TASK_NAME))
-                jar.from(main.output)
-                jar.doFirst(addManifest(MAIN_IMAGEJ, "lib"))
-            }
-        })
     }
 
     private TaskProvider<ShadowJar> addCreateImageJFatJar() {

--- a/buildSrc/src/main/groovy/org/openmicroscopy/InsightBasePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/openmicroscopy/InsightBasePlugin.groovy
@@ -45,7 +45,7 @@ class InsightBasePlugin implements Plugin<Project> {
 
     public static final String TASK_OMERO_IMAGEJ_JAR = "imageJJar"
 
-    public static final String TASK_OMERO_IMAGEJ_FAT_JAR = "imageJFatJar"
+    public static final String TASK_OMERO_IMAGEJ_FAT_JAR = TASK_OMERO_IMAGEJ_JAR//"imageJFatJar"
 
     public static final String MAIN_INSIGHT = "org.openmicroscopy.shoola.Main"
 
@@ -66,7 +66,7 @@ class InsightBasePlugin implements Plugin<Project> {
 
         configureJarTask()
         addProcessConfigs()
-        addCreateImageJJar()
+        //addCreateImageJJar()
         addCreateImageJFatJar()
     }
 
@@ -136,7 +136,7 @@ class InsightBasePlugin implements Plugin<Project> {
                 // Rename omero-insight to omero_ij
                 Jar jarTask = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME) as Jar
 
-                shadow.archiveBaseName.set(createImageJName(jarTask, "fiji"))
+                shadow.archiveBaseName.set(createImageJName(jarTask, "ij"))
                 shadow.archiveClassifier.set("all")
                 shadow.description = "Create a combined JAR of project and runtime dependencies"
                 shadow.conventionMapping.with {


### PR DESCRIPTION
This PR replaces #68
 * It creates a fat jar (due to time limit config will be included in jar in another  PR)
 * The OMERO.imagej now contains the fat jar instead to the jar and lib. This has been an issue for many users
 * Allows to use the plugin in Fiji

cc @pwalczysko 
