### PR TITLE
Hyperlink in description

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -2159,9 +2159,9 @@ class ImViewerModel
 		if (endZ < startZ) endZ = ref.getEndZ();
 		state = ImViewer.PROJECTING;
 		StringBuffer buf = new StringBuffer();
-		buf.append("Original Image:"+getImageName());
+		buf.append("Image's name:"+getImageName());
 		buf.append("\n");
-		buf.append("Original Image ID:"+getImageID());
+		buf.append("Image:"+getImageID());
 		buf.append("\n");
 		buf.append("Projection type:"+typeName);
 		buf.append("\n");

--- a/src/main/java/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -2159,13 +2159,13 @@ class ImViewerModel
 		if (endZ < startZ) endZ = ref.getEndZ();
 		state = ImViewer.PROJECTING;
 		StringBuffer buf = new StringBuffer();
-		buf.append("Original Image: "+getImageName());
+		buf.append("Original Image:"+getImageName());
 		buf.append("\n");
-		buf.append("Original Image ID: "+getImageID());
+		buf.append("Original Image ID:"+getImageID());
 		buf.append("\n");
-		buf.append("Projection type: "+typeName);
+		buf.append("Projection type:"+typeName);
 		buf.append("\n");
-		buf.append("z-sections: "+(startZ+1)+"-"+(endZ+1));
+		buf.append("z-sections:"+(startZ+1)+"-"+(endZ+1));
 		buf.append("\n");
 		
 		String imageNameWithRange = combineFilenameWith(ref.getImageName(),
@@ -2173,8 +2173,8 @@ class ImViewerModel
 		
 		int startT = ref.getStartT();
 		int endT = ref.getEndT();
-		if (startT == endT) buf.append("timepoint: "+(startT+1));
-		else buf.append("timepoints: "+(startT+1)+"-"+(endT+1));
+		if (startT == endT) buf.append("timepoint:"+(startT+1));
+		else buf.append("timepoints:"+(startT+1)+"-"+(endT+1));
 		List<Integer> channels = ref.getChannels();
 		
 		ProjectionParam param = new ProjectionParam(getPixelsID(),

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/omeeditpane/OMEWikiConstants.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/omeeditpane/OMEWikiConstants.java
@@ -71,22 +71,22 @@ public class OMEWikiConstants
 	/** Regular expression defining Dataset [Dataset: 30]. */
 	//static final String DATASETREGEX = "\\[(Dataset|dataset):[ ]*"+NUMBERREGEX+"[ ]*\\]";
 
-	static final String DATASETREGEX =  "(Dataset|dataset)\\s?(ID|id|\\s?):\\s?("+NUMBERREGEX+")";
+	static final String DATASETREGEX =  "(Dataset|dataset)\\s?(ID|id)?:\\s?("+NUMBERREGEX+")";
 	
 	/** Regular expression defining Project [Project: 30]. */
 	//static final String PROJECTREGEX = "\\[(Project|project):[ ]*"+NUMBERREGEX+"[ ]*\\]";
 	
-	static final String PROJECTREGEX =  "(Project|project)\\s?(ID|id|\\s?):\\s?("+NUMBERREGEX+")";
+	static final String PROJECTREGEX =  "(Project|project)\\s?(ID|id)?:\\s?("+NUMBERREGEX+")";
 	
 	/** Regex expression defining Image [Image: 30]. */
 	//static final String IMAGEREGEX = "\\[(Image|image):[ ]*"+NUMBERREGEX+"[ ]*\\]";
 	
-	static final String IMAGEREGEX =  "(Image|image|Image's)\\s?(ID|id|\\s?):\\s?("+NUMBERREGEX+")";
+	static final String IMAGEREGEX =  "(Image|image|Image's)\\s?(ID|id)?:\\s?("+NUMBERREGEX+")";
 	
 	/** Regex expression defining Protocol [Protocol: id 30]. */
 	//static final String PROTOCOLREGEX = "\\[(Protocol|Protocol):[ ]*"+NUMBERREGEX+"[ ]*\\]";
 
-	static final String PROTOCOLREGEX =  "(Protocol|protocol)\\s?(ID|id|\\s?):\\s?("+NUMBERREGEX+")";
+	static final String PROTOCOLREGEX =  "(Protocol|protocol)\\s?(ID|id)?:\\s?("+NUMBERREGEX+")";
 	
 	/** Regular expression expression defining Wiki Heading. */
 	static final String HEADINGREGEX = "(^[=]{3}[ ]+"+SENTENCEREGEX+"[ ]+[=]{3}[ ]*$|^[=]{2}[ ]+"+SENTENCEREGEX+"[ ]+[=]{2}[ ]*$|^[=]{1}[ ]+"+SENTENCEREGEX+"[ ]+[=]{1}[ ]*$)";

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/omeeditpane/OMEWikiConstants.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/omeeditpane/OMEWikiConstants.java
@@ -71,22 +71,22 @@ public class OMEWikiConstants
 	/** Regular expression defining Dataset [Dataset: 30]. */
 	//static final String DATASETREGEX = "\\[(Dataset|dataset):[ ]*"+NUMBERREGEX+"[ ]*\\]";
 
-	static final String DATASETREGEX =  "(Dataset|dataset) (ID|id): ("+NUMBERREGEX+")";
+	static final String DATASETREGEX =  "(Dataset|dataset) (ID|id):\\s?("+NUMBERREGEX+")";
 	
 	/** Regular expression defining Project [Project: 30]. */
 	//static final String PROJECTREGEX = "\\[(Project|project):[ ]*"+NUMBERREGEX+"[ ]*\\]";
 	
-	static final String PROJECTREGEX =  "(Project|project) (ID|id): ("+NUMBERREGEX+")";
+	static final String PROJECTREGEX =  "(Project|project) (ID|id):\\s?("+NUMBERREGEX+")";
 	
 	/** Regex expression defining Image [Image: 30]. */
 	//static final String IMAGEREGEX = "\\[(Image|image):[ ]*"+NUMBERREGEX+"[ ]*\\]";
 	
-	static final String IMAGEREGEX =  "(Image|image|Image's) (ID|id): ("+NUMBERREGEX+")";
+	static final String IMAGEREGEX =  "(Image|image|Image's) (ID|id):\\s?("+NUMBERREGEX+")";
 	
 	/** Regex expression defining Protocol [Protocol: id 30]. */
 	//static final String PROTOCOLREGEX = "\\[(Protocol|Protocol):[ ]*"+NUMBERREGEX+"[ ]*\\]";
 
-	static final String PROTOCOLREGEX =  "(Protocol|protocol) (ID|id): ("+NUMBERREGEX+")";
+	static final String PROTOCOLREGEX =  "(Protocol|protocol) (ID|id):\\s?("+NUMBERREGEX+")";
 	
 	/** Regular expression expression defining Wiki Heading. */
 	static final String HEADINGREGEX = "(^[=]{3}[ ]+"+SENTENCEREGEX+"[ ]+[=]{3}[ ]*$|^[=]{2}[ ]+"+SENTENCEREGEX+"[ ]+[=]{2}[ ]*$|^[=]{1}[ ]+"+SENTENCEREGEX+"[ ]+[=]{1}[ ]*$)";

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/omeeditpane/OMEWikiConstants.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/omeeditpane/OMEWikiConstants.java
@@ -71,22 +71,22 @@ public class OMEWikiConstants
 	/** Regular expression defining Dataset [Dataset: 30]. */
 	//static final String DATASETREGEX = "\\[(Dataset|dataset):[ ]*"+NUMBERREGEX+"[ ]*\\]";
 
-	static final String DATASETREGEX =  "(Dataset|dataset) (ID|id):\\s?("+NUMBERREGEX+")";
+	static final String DATASETREGEX =  "(Dataset|dataset)\\s?(ID|id|\\s?):\\s?("+NUMBERREGEX+")";
 	
 	/** Regular expression defining Project [Project: 30]. */
 	//static final String PROJECTREGEX = "\\[(Project|project):[ ]*"+NUMBERREGEX+"[ ]*\\]";
 	
-	static final String PROJECTREGEX =  "(Project|project) (ID|id):\\s?("+NUMBERREGEX+")";
+	static final String PROJECTREGEX =  "(Project|project)\\s?(ID|id|\\s?):\\s?("+NUMBERREGEX+")";
 	
 	/** Regex expression defining Image [Image: 30]. */
 	//static final String IMAGEREGEX = "\\[(Image|image):[ ]*"+NUMBERREGEX+"[ ]*\\]";
 	
-	static final String IMAGEREGEX =  "(Image|image|Image's) (ID|id):\\s?("+NUMBERREGEX+")";
+	static final String IMAGEREGEX =  "(Image|image|Image's)\\s?(ID|id|\\s?):\\s?("+NUMBERREGEX+")";
 	
 	/** Regex expression defining Protocol [Protocol: id 30]. */
 	//static final String PROTOCOLREGEX = "\\[(Protocol|Protocol):[ ]*"+NUMBERREGEX+"[ ]*\\]";
 
-	static final String PROTOCOLREGEX =  "(Protocol|protocol) (ID|id):\\s?("+NUMBERREGEX+")";
+	static final String PROTOCOLREGEX =  "(Protocol|protocol)\\s?(ID|id|\\s?):\\s?("+NUMBERREGEX+")";
 	
 	/** Regular expression expression defining Wiki Heading. */
 	static final String HEADINGREGEX = "(^[=]{3}[ ]+"+SENTENCEREGEX+"[ ]+[=]{3}[ ]*$|^[=]{2}[ ]+"+SENTENCEREGEX+"[ ]+[=]{2}[ ]*$|^[=]{1}[ ]+"+SENTENCEREGEX+"[ ]+[=]{1}[ ]*$)";


### PR DESCRIPTION
Unify with CLI, figure the way the link to the original image is added to the description of the projected image
UI will now handle both case ``Image ID:<space>ID`` and ``Image ID:ID``

To test: (new image)
 * Open an image with more than one z
 * project the image
 * Open the projected image
 * A link to the original image should be available i.e. ``Image:ID``. 
 * Double click to open the image. Close the viewer
 * Modify the description by adding a space i.e. ``Image:<space>ID``
 * Check that it is still highlighted in blue.
 * Double click to open the image.

To test: (projection done previously) (user-1, 92215)
 *  Open the projected image
 * A link to the original image should be available i.e. ``Image ID: <space>ID``. 
 * Modify the description by removing the a space i.e. ``Image ID:ID``
 * Check that it is still highlighted in blue.
 * Double click to open the image.
 * Modify the description by removing ID i.e. ``Image:ID``
 * Check that it is still highlighted in blue.
 * Double click to open the image.

cc @will-moore 