### PR TITLE
Login error dialog in background

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
@@ -134,6 +134,9 @@ public class LookupNames
     /** Field to access the <code>Splash screen</code> information. */
     public static final String SPLASH_SCREEN_LOGO = "SplashScreenLogo";
 
+    /** Field to access the <code>Splash screen manager</code>. */
+    public static final String SPLASH_SCREEN_MANAGER = "SplashScreenManager";
+
     /** Field to access the <code>Splash screen</code> information. */
     public static final String SPLASH_SCREEN_LOGIN = "SplashScreenLogin";
 
@@ -227,7 +230,7 @@ public class LookupNames
      */
     public static final String USER_HOME_OMERO = "/user/home/omero";
 
-    /** 
+    /**
      * Field to access the location of the <code>OMERO folder</code>
      * on the user's machine.
      */
@@ -265,7 +268,7 @@ public class LookupNames
     public static final String THUMBNAIL_FETCH_MEDIUM_SPEED =
             "/services/Thumbnailing/fetchMediumSpeed";
 
-    /** 
+    /**
      * Field to access the number of rendering engine to start for big images.
      */
     public static final String RE_WORKER = "/services/RE/worker";

--- a/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
@@ -249,13 +249,7 @@ public class LookupNames
      */
     public static final String THUMBNAIL_FETCH_MEDIUM_SPEED =
             "/services/Thumbnailing/fetchMediumSpeed";
-
-<<<<<<< HEAD
-=======
-    /** Field to access the <code>Cache on</code> information. */
-    public static final String CACHE_ON = "/services/CACHE/on";
-
->>>>>>> Remove unused code
+    
     /**
      * Field to access the number of rendering engine to start for big images.
      */
@@ -336,13 +330,13 @@ public class LookupNames
     public static final String ENTRY_POINT = "/application/entryPoint";
 
     /** Field to access the <code>Entry Point</code> information. */
-    static final String ENTRY_POINT_HIERARCHY =
+    public static final String ENTRY_POINT_HIERARCHY =
             "/application/entryPointHierarchy";
 
     /**
      * Field indicating that the application is ran head-less.
      */
-    static final String HEADLESS = "Headless";
+    public static final String HEADLESS = "Headless";
     
     /** Lookup name of the orphaned images folder */
     public static final String ORPHANED_IMAGE_NAME = "omero.client.ui.tree.orphans.name";

--- a/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
@@ -113,12 +113,6 @@ public class LookupNames
     /** Field to access the <code>Version</code> information. */
     public static final String VERSION = "Version";
 
-    /** 
-     * Field to check if the server version is 5.4.8 or later.
-     * */
-    @Deprecated
-    public static final String SERVER_5_4_8_OR_LATER = "5.4.8 or later";
-    
     /** Maximum plane width for non pyramid images **/
     public static final String MAX_PLANE_WIDTH = "/services/Thumbnailing/non_pyramid_max_plane_width";
     
@@ -136,9 +130,6 @@ public class LookupNames
 
     /** Field to access the <code>Splash screen manager</code>. */
     public static final String SPLASH_SCREEN_MANAGER = "SplashScreenManager";
-
-    /** Field to access the <code>Splash screen</code> information. */
-    public static final String SPLASH_SCREEN_LOGIN = "SplashScreenLogin";
 
     /** Field to access the <code>Help on line</code> information. */
     public static final String HELP_ON_LINE = "HelpOnLine";
@@ -171,9 +162,6 @@ public class LookupNames
 
     /** Field to access the users contained in the group. */
     public static final String USERS_DETAILS = "/users/details";
-
-    /** Field to access the LDAP user information. */
-    public static final String USER_AUTHENTICATION = "/user/authentication";
 
     /** Field indicating if the user is an administrator. */
     public static final String USER_ADMINISTRATOR = "/users/administrator";
@@ -230,12 +218,6 @@ public class LookupNames
      */
     public static final String USER_HOME_OMERO = "/user/home/omero";
 
-    /**
-     * Field to access the location of the <code>OMERO folder</code>
-     * on the user's machine.
-     */
-    public static final String USER_HOME_OMERO_FILES = "/user/home/omero/files";
-
     /** Field to access the <code>Log on</code> information. */
     public static final String LOG_ON = "/services/LOG/on";
 
@@ -268,6 +250,12 @@ public class LookupNames
     public static final String THUMBNAIL_FETCH_MEDIUM_SPEED =
             "/services/Thumbnailing/fetchMediumSpeed";
 
+<<<<<<< HEAD
+=======
+    /** Field to access the <code>Cache on</code> information. */
+    public static final String CACHE_ON = "/services/CACHE/on";
+
+>>>>>>> Remove unused code
     /**
      * Field to access the number of rendering engine to start for big images.
      */
@@ -278,11 +266,6 @@ public class LookupNames
      * is shut down. The value is in milliseconds.
      */
     public static final String RE_TIMEOUT = "/services/RE/timeout";
-
-    public static final String RE_STACK_BUF_SZ = "/services/RE/stackBufSz";
-    public static final String RE_STACK_BLOCK_SZ = "/services/RE/stackBlockSz";
-
-    public static final String RE_MAX_PRE_FETCH = "/services/RE/maxPreFetch";
 
     public static final String CMD_PROCESSOR = "/services/CmdProcessor";
 
@@ -303,11 +286,6 @@ public class LookupNames
 
     /** Field to access the <code>Log service</code> information. */
     public static final String LOGIN = "/services/Login";
-
-    /**
-     * Field to access the <code>Log service configuration</code> information.
-     */
-    public static final String LOGIN_CFG = "/services/Login/config";
 
     /**
      * Field to access the maximum number of tries in order to connect to the 
@@ -350,31 +328,21 @@ public class LookupNames
     /** Field to access the file keeping track of the various ROIs files. */
     public static final String	ROI_MAIN_FILE = "/roi/mainFileName";
 
-    //For blitz
-    /** The value to replace in the FS configuration file. */
-    public static final String FS_HOSTNAME = "/services/FS/defaultDirectory";
-
-    /** The value to replace in the FS configuration file. */
-    public static final String FS_DEFAUL_DIR = "/services/FS/defaultDirectory";
-
     /** Field to access the <code>Binary Available</code> information. */
     public static final String	BINARY_AVAILABLE =
             "/services/SERVER/BinaryAvailable";
-
-    /** Field to access <code>RAPID</code> information. */
-    public static final String	RAPID = "/services/SERVER/RAPID";
 
     /** Field to access the <code>Entry Point</code> information. */
     public static final String ENTRY_POINT = "/application/entryPoint";
 
     /** Field to access the <code>Entry Point</code> information. */
-    public static final String ENTRY_POINT_HIERARCHY =
+    static final String ENTRY_POINT_HIERARCHY =
             "/application/entryPointHierarchy";
 
-    /** 
+    /**
      * Field indicating that the application is ran head-less.
      */
-    public static final String HEADLESS = "Headless";
+    static final String HEADLESS = "Headless";
     
     /** Lookup name of the orphaned images folder */
     public static final String ORPHANED_IMAGE_NAME = "omero.client.ui.tree.orphans.name";

--- a/src/main/java/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
@@ -35,6 +35,7 @@ import Glacier2.PermissionDeniedException;
 import Ice.ConnectionRefusedException;
 import Ice.DNSException;
 
+import org.openmicroscopy.shoola.env.ui.SplashScreenManager;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 
 import omero.SecurityViolation;
@@ -308,7 +309,6 @@ public class LoginServiceImpl
      */
     public void notifyLoginFailure()
     {
-        JFrame f = container.getRegistry().getTaskBar().getFrame();
         String text = "";
         switch (failureIndex) {
         case LoginService.DNS_INDEX:
@@ -351,8 +351,9 @@ public class LoginServiceImpl
             text = "Please check your user name\nand/or password " +
                     "or try again later.";
         }
+        SplashScreenManager splash = (SplashScreenManager) container.getRegistry().lookup(LookupNames.SPLASH_SCREEN_MANAGER);
         NotificationDialog dialog = new NotificationDialog(
-                f, "Login Failure", "Failed to log onto OMERO.\n"+text,
+                splash.getFrame(), "Login Failure", "Failed to log onto OMERO.\n"+text,
                 IconManager.getDefaultErrorIcon());
         dialog.pack();  
         UIUtilities.centerAndShow(dialog);

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
@@ -35,8 +35,6 @@ import java.beans.PropertyChangeListener;
 import javax.swing.Icon;
 import javax.swing.JFrame;
 
-
-import org.openmicroscopy.shoola.Main;
 import org.openmicroscopy.shoola.env.Container;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.config.OMEROInfo;
@@ -74,7 +72,7 @@ import org.openmicroscopy.shoola.util.ui.login.ScreenLogo;
  * @since OME2.2
  */
 
-class SplashScreenManager
+public class SplashScreenManager
 	implements PropertyChangeListener, WindowFocusListener, WindowStateListener
 {
 	
@@ -222,6 +220,7 @@ class SplashScreenManager
 		container = c;
 		this.component = component;
 		Registry reg = c.getRegistry();
+		reg.bind(LookupNames.SPLASH_SCREEN_MANAGER, this);
 		String n = (String) reg.lookup(LookupNames.SPLASH_SCREEN_LOGO);
 		
 		String f = container.getConfigFileRelative(null);
@@ -409,5 +408,12 @@ class SplashScreenManager
 	 * @see WindowFocusListener#windowGainedFocus(WindowEvent)
 	 */
 	public void windowGainedFocus(WindowEvent e) {}
-	
+
+	/**
+	 * Get the splashscreen's JFrame
+	 * @return See above.
+	 */
+	public JFrame getFrame() {
+		return this.view;
+	}
 }


### PR DESCRIPTION
While investigating https://github.com/ome/omero-insight/pull/66#issuecomment-529456496 I also noticed that the login error dialog pops up in the background. 
This PR fixes the issue (and also removes some old/unused code from LookupNames class).

**Test**:
Enter some invalid credentials and/or server information. Without the PR: The error dialog pops up behind the login window (at least on debian cinnamon desktop). With PR: Error dialog pops up in foreground.
