### PR TITLE
offline import

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/OfflineImportRequestBuilder.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/OfflineImportRequestBuilder.java
@@ -66,6 +66,14 @@ class OfflineImportRequestBuilder {
             exp = svc.getUserDetails();
         }
         data.experimenterEmail = exp.getEmail();
+        //Handle the case when email is not set.
+        //Without an email the request is rejected but it does not prevent
+        //the import to go ahead. It will only not notify users when the
+        //the import is done. The email setup is not a requirement for
+        //omero-ms-queue
+        if (exp.getEmail() == null || exp.getEmail().trim().isEmpty()) {
+            data.experimenterEmail = "x@y";
+        }
         data.omeroHost = svc.getServerName();
         if (svc.getPort() > 0) {
             data.omeroPort = "" + svc.getPort();


### PR DESCRIPTION
handle case without email
If the email is not set, it is not possible to start the offline import
The import still works without this requirement.