### PR TITLE
Handle LUTs in MovieExportDialog

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/util/ui/MovieExportDialog.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/util/ui/MovieExportDialog.java
@@ -196,8 +196,10 @@ public class MovieExportDialog
 			while (i.hasNext()) {
 				entry = (Entry) i.next();
 				data = (ChannelData) entry.getKey();
-				button = new ChannelButton(data.getChannelLabeling(), 
-						(Color) entry.getValue(), data.getIndex());
+				Color buttonColor = entry.getValue() instanceof Color ?
+						(Color) entry.getValue() : Color.LIGHT_GRAY;
+				button = new ChannelButton(data.getChannelLabeling(),
+						buttonColor, data.getIndex());
 				button.setSelected(true);
 				button.addPropertyChangeListener(new PropertyChangeListener() {
 					


### PR DESCRIPTION
Show a generic grey button if channel uses lookup table.
Fixes https://github.com/ome/omero-insight/issues/85

Test: On a multi-Z/T image set one or more channels to a lookup table. Open the "Movie Export" dialog.