### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/actions/TaggingAction.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/actions/TaggingAction.java
@@ -106,7 +106,7 @@ public class TaggingAction
 			ho instanceof PlateData || ho instanceof PlateAcquisitionData) {
         	if (model.canAnnotate(ho)) {
         		List selected = browser.getSelectedDataObjects();
-        		if (selected == null) setEnabled(false);
+        		if (selected.isEmpty()) setEnabled(false);
         		else {
         			List<Long> ids = new ArrayList<Long>();
             		Iterator i = selected.iterator();

--- a/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
@@ -987,8 +987,8 @@ class BrowserComponent
     public List getSelectedDataObjects()
     {
     	TreeImageDisplay[] nodes = getSelectedDisplays();
-    	if (nodes == null || nodes.length == 0) return null;
-    	List<DataObject> objects = new ArrayList<DataObject>();
+		List<DataObject> objects = new ArrayList<DataObject>();
+    	if (nodes == null || nodes.length == 0) return objects;
     	Object uo;
     	for (int i = 0; i < nodes.length; i++) {
 			uo = nodes[i].getUserObject();

--- a/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -603,7 +603,7 @@ class TreeViewerComponent
 				setLeaves((TreeImageSet) display, s);
 				db = DataBrowserFactory.getDataBrowser(display);
 				list = browser.getSelectedDataObjects();
-				if (list != null && list.size() == 1) {
+				if (list.size() == 1) {
 					app = TreeViewerFactory.getApplications(
 					model.getObjectMimeType(list.get(0)));
 				}
@@ -695,7 +695,7 @@ class TreeViewerComponent
 						view.displayBrowser(db);
 					}
 					list = browser.getSelectedDataObjects();
-					if (list != null && list.size() == 1) {
+					if (list.size() == 1) {
 						app = TreeViewerFactory.getApplications(
 								model.getObjectMimeType(list.get(0)));
 					}
@@ -718,7 +718,7 @@ class TreeViewerComponent
 	        						setLeaves((TreeImageSet) parent, s);
 	        						db = DataBrowserFactory.getDataBrowser(ho);
 	        						list = browser.getSelectedDataObjects();
-	        						if (list != null && list.size() == 1) {
+	        						if (list.size() == 1) {
 	        							app = TreeViewerFactory.getApplications(
 	        							model.getObjectMimeType(list.get(0)));
 	        						}
@@ -747,7 +747,7 @@ class TreeViewerComponent
 	                					db = DataBrowserFactory.getDataBrowser(
 	                							ho);
 	                					list = browser.getSelectedDataObjects();
-	                					if (list != null && list.size() == 1) {
+	                					if (list.size() == 1) {
 	                						app = 
 	                						TreeViewerFactory.getApplications(
 	                						model.getObjectMimeType(
@@ -840,7 +840,7 @@ class TreeViewerComponent
         						db = DataBrowserFactory.getDataBrowser(
         								display.getUserObject());
         						list = browser.getSelectedDataObjects();
-        						if (list != null && list.size() == 1) {
+        						if (list.size() == 1) {
         							app = TreeViewerFactory.getApplications(
         								model.getObjectMimeType(list.get(0)));
         						}
@@ -3632,7 +3632,7 @@ class TreeViewerComponent
             return;
         List l = selection == null ? browser.getSelectedDataObjects()
                 : selection;
-	    if (l == null || l.isEmpty()) return;
+	    if (l.isEmpty()) return;
 	    Iterator i = l.iterator();
 	    Object object;
 	    List<DataObject> archived = new ArrayList<DataObject>();
@@ -3729,7 +3729,7 @@ class TreeViewerComponent
 				TreeViewerAgent.getRegistry().lookup(LookupNames.ENV);
 			String dir = env.getTmpDir();
 			List l = browser.getSelectedDataObjects();
-			if (l == null || l.isEmpty()) return;
+			if (l.isEmpty()) return;
 			Iterator i = l.iterator();
 			Object object;
 			OpenActivityParam activity;
@@ -3938,7 +3938,7 @@ class TreeViewerComponent
 		Browser browser = model.getSelectedBrowser();
 		if (browser == null) return;
 		List l = browser.getSelectedDataObjects();
-		if (l == null || l.isEmpty()) return;
+		if (l.isEmpty()) return;
 		Map<ExperimenterData, UserCredentials>
 			map = new HashMap<ExperimenterData, UserCredentials>();
 		Iterator i = l.iterator();
@@ -4247,7 +4247,7 @@ class TreeViewerComponent
 		Browser browser = model.getSelectedBrowser();
 		if (browser == null) return;
 		List l = browser.getSelectedDataObjects();
-		if (l == null || l.isEmpty()) return;
+		if (l.isEmpty()) return;
 		Map<ExperimenterData, UserCredentials>
 			map = new HashMap<ExperimenterData, UserCredentials>();
 		UserCredentials uc = new UserCredentials(exp.getUserName(), "");
@@ -4700,7 +4700,7 @@ class TreeViewerComponent
 		if (group == null) 
 			throw new IllegalArgumentException("No group to move data to.");
 		
-		if (nodes == null || nodes.size() == 0) return;
+		if (nodes.isEmpty()) return;
 		Map<SecurityContext, List<DataObject>> 
 		map = new HashMap<SecurityContext, List<DataObject>>();
 		Iterator<DataObject> i = nodes.iterator();

--- a/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -3632,7 +3632,7 @@ class TreeViewerComponent
             return;
         List l = selection == null ? browser.getSelectedDataObjects()
                 : selection;
-	    if (l == null) return;
+	    if (l == null || l.isEmpty()) return;
 	    Iterator i = l.iterator();
 	    Object object;
 	    List<DataObject> archived = new ArrayList<DataObject>();
@@ -3729,7 +3729,7 @@ class TreeViewerComponent
 				TreeViewerAgent.getRegistry().lookup(LookupNames.ENV);
 			String dir = env.getTmpDir();
 			List l = browser.getSelectedDataObjects();
-			if (l == null) return;
+			if (l == null || l.isEmpty()) return;
 			Iterator i = l.iterator();
 			Object object;
 			OpenActivityParam activity;
@@ -3938,7 +3938,7 @@ class TreeViewerComponent
 		Browser browser = model.getSelectedBrowser();
 		if (browser == null) return;
 		List l = browser.getSelectedDataObjects();
-		if (l == null) return;
+		if (l == null || l.isEmpty()) return;
 		Map<ExperimenterData, UserCredentials>
 			map = new HashMap<ExperimenterData, UserCredentials>();
 		Iterator i = l.iterator();
@@ -4247,7 +4247,7 @@ class TreeViewerComponent
 		Browser browser = model.getSelectedBrowser();
 		if (browser == null) return;
 		List l = browser.getSelectedDataObjects();
-		if (l == null) return;
+		if (l == null || l.isEmpty()) return;
 		Map<ExperimenterData, UserCredentials>
 			map = new HashMap<ExperimenterData, UserCredentials>();
 		UserCredentials uc = new UserCredentials(exp.getUserName(), "");

--- a/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
@@ -769,7 +769,7 @@ class TreeViewerControl
 		List<Long> owners = new ArrayList<Long>();
 		if (browser != null) {
 			selection = browser.getSelectedDataObjects();
-			if (selection == null || selection.isEmpty()) return null;
+			if (selection.isEmpty()) return null;
 			int count = 0;
 			j = selection.iterator();
 			Object o;

--- a/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
@@ -769,7 +769,7 @@ class TreeViewerControl
 		List<Long> owners = new ArrayList<Long>();
 		if (browser != null) {
 			selection = browser.getSelectedDataObjects();
-			if (selection == null) return null;
+			if (selection == null || selection.isEmpty()) return null;
 			int count = 0;
 			j = selection.iterator();
 			Object o;


### PR DESCRIPTION
Return an empty list instead of null for `BrowserComponent.getSelectedDataObjects()`.
That should fix https://www.openmicroscopy.org/qa2/qa/feedback/27973/ and prevent similar potential NPEs.