### PR TITLE
Disable ome-tiff export for 'large' images

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -187,6 +187,10 @@ class ToolBar
         downloadItem.setEnabled(b);
         saveAsMenu.add(downloadItem);
 
+		Object ho = model.getRefObject();
+		boolean enabled = (ho instanceof ImageData ||
+				ho instanceof WellSampleData || ho instanceof DatasetData) && model.isExportable();
+
         exportAsOmeTiffItem = new JMenuItem(icons.getIcon(
                 IconManager.EXPORT_AS_OMETIFF));
         exportAsOmeTiffItem.setText("Export as OME-TIFF...");
@@ -199,7 +203,7 @@ class ToolBar
             b = model.getRefObject() instanceof ImageData &&
                     !model.isLargeImage();
         }
-        exportAsOmeTiffItem.setEnabled(b);
+        exportAsOmeTiffItem.setEnabled(enabled);
         saveAsMenu.add(exportAsOmeTiffItem);
         ActionListener l = new ActionListener() {
             public void actionPerformed(ActionEvent e) {
@@ -211,9 +215,6 @@ class ToolBar
         Entry<Integer, String> e;
         Iterator<Entry<Integer, String>> i = formats.entrySet().iterator();
         JMenuItem item;
-        Object ho = model.getRefObject();
-        boolean enabled = (ho instanceof ImageData ||
-                ho instanceof WellSampleData || ho instanceof DatasetData) && model.isExportable();
         while (i.hasNext()) {
             e = i.next();
             item = new JMenuItem(icons.getIcon(


### PR DESCRIPTION
See title. Fixes https://github.com/ome/omero-insight/issues/86 , resp. https://www.openmicroscopy.org/qa2/qa/feedback/27969/

To reproduce: Increase the max plane size on the server (`omero.pixeldata.max_plane_height` , `omero.pixeldata.max_plane_width`). Without the PR the ome-tiff export button becomes enabled, because it's not considered as big image. 'big' image is `omero.pixeldata.max_plane...` in contrast to 'large' image which is  `omero.client.download_as.max_size`. With the PR `omero.client.download_as.max_size` will be taken to decide if the button should be enabled (like it already was the case for png, jpeg etc.).
