### PR TITLE
Fix version error message

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
@@ -328,12 +328,12 @@ public class LoginServiceImpl
             text = "Error: System Failure.";
             break;
         case LoginService.VERSION_MISMATCH:
-            String cv = "";
-            try {
-                cv = failureDetails.split("\\s")[2];
-            } catch (Exception e) {
-                // just ignore
-            }
+            String cv = this.getClass().getPackage().getImplementationVersion();
+            if (cv == null)
+                cv = "This Insight version";
+            else
+                cv = "Insight version "+cv;
+
             String sv = "";
             try {
                 String[] tmp = failureDetails.split("\\s");
@@ -342,9 +342,7 @@ public class LoginServiceImpl
             } catch (Exception e) {
                 // just ignore
             }
-            text = getAgent()+" version "+ cv
-                    + " is not compatible with the server version.\n"
-                    + "Please download the latest "+ sv + " "+getAgent()+".";
+            text = cv + " is not compatible with the server version "+sv+".";
             break;
         case LoginService.PERMISSION_INDEX:
         default:

--- a/src/main/java/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
@@ -329,7 +329,7 @@ public class LoginServiceImpl
             break;
         case LoginService.VERSION_MISMATCH:
             String cv = this.getClass().getPackage().getImplementationVersion();
-            if (cv == null)
+            if (cv == null || cv.isEmpty())
                 cv = "This "+getAgent()+" version";
             else
                 cv = getAgent()+" version "+cv;

--- a/src/main/java/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
@@ -330,9 +330,9 @@ public class LoginServiceImpl
         case LoginService.VERSION_MISMATCH:
             String cv = this.getClass().getPackage().getImplementationVersion();
             if (cv == null)
-                cv = "This Insight version";
+                cv = "This "+getAgent()+" version";
             else
-                cv = "Insight version "+cv;
+                cv = getAgent()+" version "+cv;
 
             String sv = "";
             try {


### PR DESCRIPTION
If you connect with current Insight 5.5.6 to for example merge-ci you get an error message like this:

![Screen Shot 2019-12-12 at 11 36 29](https://user-images.githubusercontent.com/6575139/70709123-12117580-1cd4-11ea-880a-fdda1c7ff808.png)

It says Insight 5.5.4 because it gets the version of the java-gateway. This PR simply fixes the error message, so that it correctly states the version of Insight not the gateway one. Also removes the "Please download..." sentence, as we can't automatically determine any more which Insight version will be compatible with which server version.

See also https://forum.image.sc/t/omero-python-3-5-6-milestone-for-upgrade-testing/32120/5
