### PR TITLE
fix missing icons

### DIFF
--- a/src/config/dataBrowser.xml
+++ b/src/config/dataBrowser.xml
@@ -9,7 +9,7 @@
        <structuredEntry name="/resources/icons/Factory" type = "icons">
          <!-- The location tag specifies the FQN of the package that contains
          the icon files. -->
-         <location>images.agents.dataBrowser</location>
+         <location>images.agents.databrowser</location>
        </structuredEntry>
 
      </iconFactories>


### PR DESCRIPTION
Folder was renamed to ``databrowser`` see https://github.com/ome/omero-insight/tree/47e40da08b9cff563df9894bc5490c15b545b17a/src/main/resources/images/agents/databrowser
but the value was not updated in the configuration file.
See https://github.com/ome/omero-insight/issues/55

cc @dominikl 