### PR TITLE
IJ plugin open image when using websocket

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/env/ui/TaskBarManager.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/TaskBarManager.java
@@ -330,7 +330,7 @@ public class TaskBarManager
 		StringBuffer buffer = new StringBuffer();
 		try {
 			buffer.append("location=[OMERO] open=[omero:server=");
-			buffer.append(lc.getServer().getHostname());
+			buffer.append(lc.getServer().getHost());
 			buffer.append("\nuser=");
 			buffer.append(lc.getUser().getUsername());
 			buffer.append("\nport=");


### PR DESCRIPTION
Fix issue preventing to open images using B-F when using the imagej plugin

To test:
 * Download the ``omero_ij`` jar
 * connect to a server with ws enable e.g. workshop or outreach
 * Open an image in ImageJ
 * The image should open 
cc @pwalczysko @dominikl 