### PR TITLE
Provide error message if unsupported protocol was used

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
@@ -36,7 +36,6 @@ import javax.swing.Icon;
 import javax.swing.JFrame;
 
 
-import org.openmicroscopy.shoola.Main;
 import org.openmicroscopy.shoola.env.Container;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.config.OMEROInfo;
@@ -44,8 +43,8 @@ import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.login.UserCredentials;
 import org.openmicroscopy.shoola.util.image.geom.Factory;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
-import org.openmicroscopy.shoola.util.ui.login.ScreenLogin;
-import org.openmicroscopy.shoola.util.ui.login.ScreenLogo;
+import org.openmicroscopy.shoola.env.ui.login.ScreenLogin;
+import org.openmicroscopy.shoola.env.ui.login.ScreenLogo;
 
 /** 
  * Manages the splash screen input, data and update.

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/SplashScreenManager.java
@@ -169,7 +169,7 @@ class SplashScreenManager
 
         boolean serverAvailable = connectToServer();
     	view = new ScreenLogin(Container.TITLE, splashscreen, img, clientVersion,
-    			 serverAvailable);
+    			 serverAvailable, container.getRegistry());
     	view.setEncryptionConfiguration(info.isEncrypted(),
     			info.isEncryptedConfigurable());
     	view.setDefaultHostConfiguration(info, configurable);

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/TaskBarManager.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/TaskBarManager.java
@@ -82,8 +82,8 @@ import org.openmicroscopy.shoola.util.ui.BrowserLauncher;
 import org.openmicroscopy.shoola.util.ui.MacOSMenuHandler;
 import org.openmicroscopy.shoola.util.ui.MessageBox;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
-import org.openmicroscopy.shoola.util.ui.login.ScreenLogin;
-import org.openmicroscopy.shoola.util.ui.login.ScreenLoginDialog;
+import org.openmicroscopy.shoola.env.ui.login.ScreenLogin;
+import org.openmicroscopy.shoola.env.ui.login.ScreenLoginDialog;
 import org.openmicroscopy.shoola.util.file.IOUtil;
 
 import omero.gateway.model.ExperimenterData;

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/login/ScreenLogin.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/login/ScreenLogin.java
@@ -18,7 +18,7 @@
  *
  *------------------------------------------------------------------------------
  */
-package org.openmicroscopy.shoola.util.ui.login;
+package org.openmicroscopy.shoola.env.ui.login;
 
 
 import java.awt.Color;

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/login/ScreenLogin.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/login/ScreenLogin.java
@@ -697,17 +697,6 @@ public class ScreenLogin
 		login.setEnabled(enabled);
 		configButton.setEnabled(this.configurable);
 		if (enabled) {
-			ActionListener[] listeners = login.getActionListeners();
-			if (listeners != null) {
-				boolean set = false;
-				for (int i = 0; i < listeners.length; i++) {
-					if (listeners[i] == this) {
-						set = true;
-						break;
-					}
-				}
-				if (!set) login.addActionListener(this);
-			}
 			login.setForeground(defaultForeground);
 		} else {
 			login.setForeground(FOREGROUND_COLOR);

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/login/ScreenLoginDialog.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/login/ScreenLoginDialog.java
@@ -1,5 +1,5 @@
 /*
- * org.openmicroscopy.shoola.util.ui.login.ScreenLoginDialog 
+ * org.openmicroscopy.shoola.env.ui.login.ScreenLoginDialog
  *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2009 University of Dundee. All rights reserved.
@@ -20,7 +20,7 @@
  *
  *------------------------------------------------------------------------------
  */
-package org.openmicroscopy.shoola.util.ui.login;
+package org.openmicroscopy.shoola.env.ui.login;
 
 
 import org.openmicroscopy.shoola.env.config.OMEROInfo;

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/login/ScreenLogo.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/login/ScreenLogo.java
@@ -1,5 +1,5 @@
 /*
- * org.openmicroscopy.shoola.util.ui.login.ScreenLogo 
+ * org.openmicroscopy.shoola.env.ui.login.ScreenLogo
  *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006 University of Dundee. All rights reserved.
@@ -20,7 +20,7 @@
  *
  *------------------------------------------------------------------------------
  */
-package org.openmicroscopy.shoola.util.ui.login;
+package org.openmicroscopy.shoola.env.ui.login;
 
 
 //Java imports

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/login/ServerDialog.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/login/ServerDialog.java
@@ -1,5 +1,5 @@
 /*
- * org.openmicroscopy.shoola.util.ui.login.ServerDialog 
+ * org.openmicroscopy.shoola.env.ui.login.ServerDialog
  *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006 University of Dundee. All rights reserved.
@@ -20,7 +20,7 @@
  *
  *------------------------------------------------------------------------------
  */
-package org.openmicroscopy.shoola.util.ui.login;
+package org.openmicroscopy.shoola.env.ui.login;
 
 
 import java.awt.BorderLayout;

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/login/ServerEditor.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/login/ServerEditor.java
@@ -414,15 +414,32 @@ public class ServerEditor
 	 */
 	List<String> getServers()
 	{
-    	Preferences prefs = Preferences.userNodeForPackage(ServerEditor.class);
-        String servers = prefs.get(OMERO_SERVER, null);
-        if (servers == null || servers.length() == 0)
-            return new ArrayList<>();
-        String[] l = servers.split(SERVER_NAME_SEPARATOR, 0);
+		Preferences prefs = Preferences.userNodeForPackage(ServerEditor.class);
+        List<String> servers = getServersFromPrefs(prefs);
+
+        // Workaround to load old preferences (remove again in next release):
+		Preferences oldPrefs = Preferences.userNodeForPackage(org.openmicroscopy.shoola.util.ui.login.ServerEditor.class);
+		servers.addAll(getServersFromPrefs(oldPrefs));
+
+		return servers;
+	}
+
+	/**
+	 * Returns the list of existing servers from the provided Preferences
+	 *
+	 * @param prefs The Preferences
+	 * @return See above.
+	 */
+	private List<String> getServersFromPrefs(Preferences prefs)
+	{
+		String servers = prefs.get(OMERO_SERVER, null);
+		if (servers == null || servers.length() == 0)
+			return new ArrayList<>();
+		String[] l = servers.split(SERVER_NAME_SEPARATOR, 0);
 		for (int i=0; i<l.length; i++)
 			l[i] = l[i].replace(":"+DEFAULT_PORT, "");
-        if (l == null)
-        	return new ArrayList<>();
+		if (l == null)
+			return new ArrayList<>();
 		return Stream.of(l).collect(Collectors.toList());
 	}
 	

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/login/ServerEditor.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/login/ServerEditor.java
@@ -419,7 +419,10 @@ public class ServerEditor
 
         // Workaround to load old preferences (remove again in next release):
 		Preferences oldPrefs = Preferences.userNodeForPackage(org.openmicroscopy.shoola.util.ui.login.ServerEditor.class);
-		servers.addAll(getServersFromPrefs(oldPrefs));
+		for (String s : getServersFromPrefs(oldPrefs)) {
+			if (!servers.contains(s))
+				servers.add(0, s);
+		}
 
 		return servers;
 	}

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/login/ServerEditor.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/login/ServerEditor.java
@@ -1,5 +1,5 @@
 /*
- * org.openmicroscopy.shoola.util.ui.login.ServerEditor 
+ * org.openmicroscopy.shoola.env.ui.login.ServerEditor
  *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2019 University of Dundee. All rights reserved.
@@ -20,7 +20,7 @@
  *
  *------------------------------------------------------------------------------
  */
-package org.openmicroscopy.shoola.util.ui.login;
+package org.openmicroscopy.shoola.env.ui.login;
 
 
 import java.awt.Color;

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/login/ScreenLogin.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/login/ScreenLogin.java
@@ -62,6 +62,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
 import org.openmicroscopy.shoola.env.config.OMEROInfo;
+import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.login.UserCredentials;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 
@@ -227,7 +228,10 @@ public class ScreenLogin
     private JButton helpButton;
 
     private boolean configurable = true;
-    
+
+    /** Reference to the Registry */
+    private Registry registry;
+
 	/** Quits the application. */
 	private void quit()
 	{
@@ -267,8 +271,15 @@ public class ScreenLogin
 			firePropertyChange(LOGIN_PROPERTY, null, lc);
 		} catch (IllegalArgumentException e) {
 			// an unsuppported server URL has been specified
-			JOptionPane.showMessageDialog(this, e.getMessage(),
-					"Error", JOptionPane.ERROR_MESSAGE);
+			if (this.registry != null) {
+				this.registry.getUserNotifier().notifyError("Error",
+						"There is a problem with the server name or URL:\n"+e.getMessage());
+			} else {
+				JOptionPane.showMessageDialog(this, e.getMessage(),
+						"Error", JOptionPane.ERROR_MESSAGE);
+			}
+			setControlsEnabled(true);
+			requestFocusOnField();
 		}
 	}
 
@@ -806,9 +817,10 @@ public class ScreenLogin
 	 * connect to a server, <code>false</code> otherwise.
 	 */
 	public ScreenLogin(String title, Icon logo, Image frameIcon, String version,
-			boolean serverAvailable)
+					   boolean serverAvailable, Registry registry)
 	{
 		super(title);
+		this.registry = registry;
 		setName("login window");
 		Dimension d;
 		if (logo != null)
@@ -851,7 +863,7 @@ public class ScreenLogin
 	 */
 	public ScreenLogin(String title, Icon logo, Image frameIcon, String version)
 	{
-		this(title, logo, frameIcon, version, true);
+		this(title, logo, frameIcon, version, true, null);
 	}
 
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/login/ScreenLogin.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/login/ScreenLogin.java
@@ -256,14 +256,20 @@ public class ScreenLogin
 		if (usr != null) usr = usr.trim();
 		if (s != null) s = s.trim();
 		setControlsEnabled(false);
-		UserCredentials lc= new UserCredentials(usr, psw, s, speedIndex);
-		lc.setEncrypted(encrypted);
-		setUserName(usr);
-		setEncrypted();
-		setControlsEnabled(false);
-		loginAttempt = true;
-		login.setEnabled(false);
-		firePropertyChange(LOGIN_PROPERTY, null, lc);
+		try {
+			UserCredentials lc = new UserCredentials(usr, psw, s, speedIndex);
+			lc.setEncrypted(encrypted);
+			setUserName(usr);
+			setEncrypted();
+			setControlsEnabled(false);
+			loginAttempt = true;
+			login.setEnabled(false);
+			firePropertyChange(LOGIN_PROPERTY, null, lc);
+		} catch (IllegalArgumentException e) {
+			// an unsuppported server URL has been specified
+			JOptionPane.showMessageDialog(this, e.getMessage(),
+					"Error", JOptionPane.ERROR_MESSAGE);
+		}
 	}
 
 	/** 

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/login/ServerEditor.java
@@ -1,0 +1,9 @@
+package org.openmicroscopy.shoola.util.ui.login;
+
+public class ServerEditor {
+    /**
+     * This class doesn't do anything, it's just used to load the old
+     * server settings.
+     * Todo: Remove in next release.
+     */
+}


### PR DESCRIPTION
See Gateway PR https://github.com/ome/omero-gateway-java/pull/34 , respectively issue https://github.com/ome/omero-gateway-java/issues/33 .

**Test**
Check that 'normal' login (hostname) and websocket login still works.
Check that you get a sensible error message if you try something like 'smb://someserver.org' .

