### PR TITLE
File filter

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -229,18 +229,18 @@ class EditorControl
 	private void createFileFilters()
 	{
 		filters = new ArrayList<FileFilter>();
-		filters.add(new PDFFilter());
-		filters.add(new PNGFilter());
+		filters.add(new CSVFilter());
+		filters.add(new ExcelFilter());
 		filters.add(new HTMLFilter());
 		filters.add(new JPEGFilter());
-		filters.add(new ExcelFilter());
-		filters.add(new WordFilter());
-		filters.add(new PowerPointFilter());
 		filters.add(new OpenDocumentFilter());
-		filters.add(new XMLFilter());
-		filters.add(new TIFFFilter());
-		filters.add(new CSVFilter());
+		filters.add(new PDFFilter());
+		filters.add(new PNGFilter());
+		filters.add(new PowerPointFilter());
 		filters.add(new TEXTFilter());
+		filters.add(new TIFFFilter());
+		filters.add(new WordFilter());
+		filters.add(new XMLFilter());
 		exportFilters = new ArrayList<FileFilter>();
 		exportFilters.add(new OMETIFFFilter());
 	}

--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -230,7 +230,7 @@ class EditorControl
 	{
 		filters = new ArrayList<FileFilter>();
 		filters.add(new CSVFilter());
-		filters.add(new ExcelFilter());
+		filters.add(new WordFilter());
 		filters.add(new HTMLFilter());
 		filters.add(new JPEGFilter());
 		filters.add(new OpenDocumentFilter());
@@ -239,7 +239,7 @@ class EditorControl
 		filters.add(new PowerPointFilter());
 		filters.add(new TEXTFilter());
 		filters.add(new TIFFFilter());
-		filters.add(new WordFilter());
+		filters.add(new ExcelFilter());
 		filters.add(new XMLFilter());
 		exportFilters = new ArrayList<FileFilter>();
 		exportFilters.add(new OMETIFFFilter());

--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -75,6 +75,7 @@ import omero.log.Logger;
 import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
 import org.openmicroscopy.shoola.env.ui.RefWindow;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
+import org.openmicroscopy.shoola.util.filter.file.CSVFilter;
 import org.openmicroscopy.shoola.util.filter.file.ExcelFilter;
 import org.openmicroscopy.shoola.util.filter.file.HTMLFilter;
 import org.openmicroscopy.shoola.util.filter.file.JPEGFilter;
@@ -227,6 +228,7 @@ class EditorControl
 	private void createFileFilters()
 	{
 		filters = new ArrayList<FileFilter>();
+		filters.add(new CSVFilter());
 		filters.add(new PDFFilter());
 		filters.add(new PNGFilter());
 		filters.add(new HTMLFilter());

--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -229,18 +229,18 @@ class EditorControl
 	private void createFileFilters()
 	{
 		filters = new ArrayList<FileFilter>();
+		filters.add(new PDFFilter());
 		filters.add(new CSVFilter());
-		filters.add(new WordFilter());
 		filters.add(new HTMLFilter());
 		filters.add(new JPEGFilter());
-		filters.add(new OpenDocumentFilter());
-		filters.add(new PDFFilter());
-		filters.add(new PNGFilter());
-		filters.add(new PowerPointFilter());
-		filters.add(new TEXTFilter());
-		filters.add(new TIFFFilter());
 		filters.add(new ExcelFilter());
+		filters.add(new PowerPointFilter());
+		filters.add(new WordFilter());
+		filters.add(new OpenDocumentFilter());
+		filters.add(new PNGFilter());
 		filters.add(new XMLFilter());
+		filters.add(new TIFFFilter());
+		filters.add(new TEXTFilter());
 		exportFilters = new ArrayList<FileFilter>();
 		exportFilters.add(new OMETIFFFilter());
 	}

--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -80,6 +80,7 @@ import org.openmicroscopy.shoola.util.filter.file.ExcelFilter;
 import org.openmicroscopy.shoola.util.filter.file.HTMLFilter;
 import org.openmicroscopy.shoola.util.filter.file.JPEGFilter;
 import org.openmicroscopy.shoola.util.filter.file.OMETIFFFilter;
+import org.openmicroscopy.shoola.util.filter.file.OpenDocumentFilter;
 import org.openmicroscopy.shoola.util.filter.file.PDFFilter;
 import org.openmicroscopy.shoola.util.filter.file.PNGFilter;
 import org.openmicroscopy.shoola.util.filter.file.PowerPointFilter;
@@ -228,7 +229,6 @@ class EditorControl
 	private void createFileFilters()
 	{
 		filters = new ArrayList<FileFilter>();
-		filters.add(new CSVFilter());
 		filters.add(new PDFFilter());
 		filters.add(new PNGFilter());
 		filters.add(new HTMLFilter());
@@ -236,8 +236,10 @@ class EditorControl
 		filters.add(new ExcelFilter());
 		filters.add(new WordFilter());
 		filters.add(new PowerPointFilter());
+		filters.add(new OpenDocumentFilter());
 		filters.add(new XMLFilter());
 		filters.add(new TIFFFilter());
+		filters.add(new CSVFilter());
 		filters.add(new TEXTFilter());
 		exportFilters = new ArrayList<FileFilter>();
 		exportFilters.add(new OMETIFFFilter());

--- a/src/main/java/org/openmicroscopy/shoola/util/filter/file/CSVFilter.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/filter/file/CSVFilter.java
@@ -53,6 +53,9 @@ public class CSVFilter
 	/** Possible file extension. */
 	public static final String  CSV = "csv";
 
+	/** Possible file extension. */
+	public static final String  TSV = "tsv";
+
 	/** The possible extensions. */
 	public static final String[] extensions;
 	
@@ -60,11 +63,12 @@ public class CSVFilter
 	private static final String	description;
 	
 	static {
-		extensions = new String[1];
+		extensions = new String[2];
 		extensions[0] = CSV;
-		
+		extensions[1] = TSV;
+
 		StringBuffer s = new StringBuffer();
-		s.append( "Comma Separated Value (");
+		s.append( "Comma/Tab Separated Value (");
 		for (int i = 0; i < extensions.length; i++) {
 			s.append("*."+extensions[i]);
 			if (i < extensions.length-1)
@@ -78,7 +82,7 @@ public class CSVFilter
 	 * 	Overridden to return the MIME type.
 	 * 	@see CustomizedFileFilter#getMIMEType()
 	 */
-	public String getMIMEType() { return "text/css"; }
+	public String getMIMEType() { return "text/csv"; }
 	
 	/**
 	 * 	Overridden to return the extension of the filter.

--- a/src/main/java/org/openmicroscopy/shoola/util/filter/file/ExcelFilter.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/filter/file/ExcelFilter.java
@@ -51,6 +51,18 @@ public class ExcelFilter
     /** Possible file extension. */
     public static final String  EXCEL = "xls";
 
+	/** Possible file extension. */
+	public static final String  EXCEL_X = "xlsx";
+
+	/** Possible file extension. */
+	public static final String  EXCEL_M = "xlsm";
+
+	/** Possible file extension. */
+	public static final String  EXCEL_TX = "xltx";
+
+	/** Possible file extension. */
+	public static final String  EXCEL_TM = "xltm";
+
 	/** The possible extensions. */
     public static final String[] 	extensions;
 	
@@ -58,8 +70,12 @@ public class ExcelFilter
 	private static final String		description;
 	
 	static {
-		extensions = new String[1];
+		extensions = new String[5];
 		extensions[0] = EXCEL;
+		extensions[1] = EXCEL_X;
+		extensions[2] = EXCEL_M;
+		extensions[3] = EXCEL_TX;
+		extensions[4] = EXCEL_TM;
 		StringBuffer s = new StringBuffer();
 		s.append("Microsoft Excel (");
 		for (int i = 0; i < extensions.length; i++) {

--- a/src/main/java/org/openmicroscopy/shoola/util/filter/file/OpenDocumentFilter.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/filter/file/OpenDocumentFilter.java
@@ -1,8 +1,5 @@
-/*
- * org.openmicroscopy.shoola.util.filter.file.CSVFilter 
- *
-  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+/*------------------------------------------------------------------------------
+ *  Copyright (C) 2020 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -23,28 +20,16 @@
 package org.openmicroscopy.shoola.util.filter.file;
 
 
-
-//Java imports
-
 import javax.swing.filechooser.FileFilter;
 import java.io.File;
 
-//Third-party libraries
-
-//Application-internal dependencies
 
 /** 
  * 
- * Filters the <code>CSV</code> files. 
+ * Filters the <code>Open Document</code> files.
  * 
- * @author  Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
- * 	<a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
- * @author	Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
- * 	<a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
- * @version 3.0
- * <small>
- * (<b>Internal version:</b> $Revision: $Date: $)
- * </small>
+ * @author  Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp;
+ * 	<a href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
  * @since OME3.0
  */
 public class OpenDocumentFilter

--- a/src/main/java/org/openmicroscopy/shoola/util/filter/file/OpenDocumentFilter.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/filter/file/OpenDocumentFilter.java
@@ -1,0 +1,137 @@
+/*
+ * org.openmicroscopy.shoola.util.filter.file.CSVFilter 
+ *
+  *------------------------------------------------------------------------------
+ *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *
+ *
+ * 	This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.util.filter.file;
+
+
+
+//Java imports
+
+import javax.swing.filechooser.FileFilter;
+import java.io.File;
+
+//Third-party libraries
+
+//Application-internal dependencies
+
+/** 
+ * 
+ * Filters the <code>CSV</code> files. 
+ * 
+ * @author  Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ * 	<a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author	Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
+ * 	<a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
+ * @version 3.0
+ * <small>
+ * (<b>Internal version:</b> $Revision: $Date: $)
+ * </small>
+ * @since OME3.0
+ */
+public class OpenDocumentFilter
+	extends CustomizedFileFilter
+{
+
+	/** Possible file extension. */
+	public static final String  ODT = "odt";
+
+	/** Possible file extension. */
+	public static final String  OTT = "ott";
+
+	/** Possible file extension. */
+	public static final String  ODS = "ods";
+
+	/** Possible file extension. */
+	public static final String  ODM = "odm";
+
+	/** Possible file extension. */
+	public static final String  ODP = "odp";
+
+	/** Possible file extension. */
+	public static final String  ODG = "odg";
+
+	/** The possible extensions. */
+	public static final String[] extensions;
+	
+	/** The description of the filter. */
+	private static final String	description;
+	
+	static {
+		extensions = new String[6];
+		extensions[0] = ODT;
+		extensions[1] = OTT;
+		extensions[2] = ODS;
+		extensions[3] = ODM;
+		extensions[4] = ODP;
+		extensions[5] = ODG;
+
+		StringBuffer s = new StringBuffer();
+		s.append( "Open Document Format (");
+		for (int i = 0; i < extensions.length; i++) {
+			s.append("*."+extensions[i]);
+			if (i < extensions.length-1)
+				s.append(", ");
+		}
+		s.append(")");
+		description = s.toString();
+	}
+	
+	/**
+	 * 	Overridden to return the MIME type.
+	 * 	@see CustomizedFileFilter#getMIMEType()
+	 */
+	public String getMIMEType() { return "application/vnd.oasis.opendocument"; }
+	
+	/**
+	 * 	Overridden to return the extension of the filter.
+	 * 	@see CustomizedFileFilter#getExtension()
+	 */
+	public String getExtension() { return ODT; }
+	
+	/**
+	 * 	Overridden to return the description of the filter.
+	 * 	@see FileFilter#getDescription()
+	 */
+	public String getDescription() { return description; }
+    
+	/**
+	 * 	Overridden to accept file with the declared file extensions.
+	 * @see FileFilter#accept(File)
+	 */
+	public boolean accept(File f)
+	{
+		if (f == null) return false;
+		if (f.isDirectory()) return true;
+		return isSupported(f.getName(), extensions);
+	}
+	
+	/**
+	 * Overridden to accept the file identified by its name.
+	 * @see CustomizedFileFilter#accept(String)
+	 */
+	public boolean accept(String fileName)
+	{
+		return isSupported(fileName, extensions);
+	}
+	
+}
+

--- a/src/main/java/org/openmicroscopy/shoola/util/filter/file/WordFilter.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/filter/file/WordFilter.java
@@ -56,7 +56,13 @@ public class WordFilter
     
     /** Possible file extension. */
     public static final String  WORD_T = "doct";
-    
+
+	/** Possible file extension. */
+	public static final String  WORD_M = "docm";
+
+	/** Possible file extension. */
+	public static final String  WORD_B = "docb";
+
 	/** The possible extensions. */
     public static final String[]	extensions;
 	
@@ -64,10 +70,12 @@ public class WordFilter
 	private static final String		description;
 		
 	static {
-		extensions = new String[3];
+		extensions = new String[5];
 		extensions[0] = WORD;
 		extensions[1] = WORD_X;
 		extensions[2] = WORD_T;
+		extensions[3] = WORD_M;
+		extensions[4] = WORD_B;
 		
 		StringBuffer s = new StringBuffer();
 		s.append("Microsoft Word (");


### PR DESCRIPTION
Add `csv` to the available file filters for the file attachment dialog. On that occassion also added the various "new" excel and word extensions and a filter for OpenDocument formats.
See: https://github.com/ome/omero-insight/issues/117
