### PR TITLE
Import in wrong dataset

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/FileSelectionTable.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/FileSelectionTable.java
@@ -86,7 +86,7 @@ class FileSelectionTable
 
 	/** Description of the <code>Add All</code> action.*/
 	private static final String TOOLTIP_BUTTON_ADD = "Add the selected files"+
-	        "to the queue.";
+	        " to the queue.";
 
 	/** Tooltip text for group column */
 	private static final String TOOLTIP_GROUP = 

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -42,13 +42,14 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
+import java.util.Map.Entry;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -82,6 +83,7 @@ import org.jdesktop.swingx.JXTaskPane;
 import org.openmicroscopy.shoola.agents.fsimporter.IconManager;
 import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
 import org.openmicroscopy.shoola.agents.fsimporter.actions.ImporterAction;
+import org.openmicroscopy.shoola.agents.fsimporter.util.ObjectToCreate;
 import org.openmicroscopy.shoola.agents.fsimporter.view.ImportLocationDetails;
 import org.openmicroscopy.shoola.agents.fsimporter.view.Importer;
 import org.openmicroscopy.shoola.agents.util.SelectionWizard;
@@ -1755,9 +1757,13 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 							.getValue());
 			}
 		} else if (ImportDialog.PROPERTY_GROUP_CHANGED.equals(name)
-				|| ImportDialog.REFRESH_LOCATION_PROPERTY.equals(name)
-				|| ImportDialog.CREATE_OBJECT_PROPERTY.equals(name)) {
+				|| ImportDialog.REFRESH_LOCATION_PROPERTY.equals(name)) {
 			firePropertyChange(name, evt.getOldValue(), evt.getNewValue());
+		} else if (ImportDialog.CREATE_OBJECT_PROPERTY.equals(name)) {
+
+			ObjectToCreate o = (ObjectToCreate) evt.getNewValue();
+			onDataObjectSaved(o.getChild(), null);
+
 		} else if (LocationDialog.ADD_TO_QUEUE_PROPERTY.equals(name)) {
 		    Object src = evt.getSource();
 		    if (src != detachedDialog) {

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -1181,7 +1181,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		if (!reload) {
 			while (i.hasNext()) {
 				file = i.next();
-				if (file.isFolderAsContainer()
+				if ((file.isFolderAsContainer() || !file.isDatasetCreated())
 						&& !ImportableObject.isHCSFile(file.getFile())) {
 					// going to check if the dataset has been created.
 					reload = true;

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -1188,6 +1188,7 @@ class LocationDialog extends JDialog implements ActionListener,
 							long loggedUserID, boolean isAdmin, boolean userIsAdmin)
 	{
 		//data owner
+		if (node.getId() < 0) return true;
 		if (node.getOwner().getId() == userID) return true;
 		if (!node.canLink()) return false; //handle private group case.
 		PermissionData permissions = group.getPermissions();
@@ -1579,13 +1580,18 @@ class LocationDialog extends JDialog implements ActionListener,
 			}
 		}
 		Iterator<DataNode> i = nodes.iterator();
+		ExperimenterData exp = getSelectedUser();
 		while (i.hasNext()) {
 			node = i.next();
 			if (!node.isDefaultNode()) {
-				map.put(node.getDataObject().getOwner().getId(), node);
+				ExperimenterData owner = node.getDataObject().getOwner();
+				if (owner != null) {
+					map.put(owner.getId(), node);
+				} else {
+					map.put(exp.getId(), node);
+				}
 			}
 		}
-		ExperimenterData exp = getSelectedUser();
 		List<DataNode> l = null;
 		if (exp != null) l = map.get(exp.getId());
 		if (CollectionUtils.isNotEmpty(l))

--- a/src/main/java/org/openmicroscopy/shoola/env/data/model/ImportableFile.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/model/ImportableFile.java
@@ -144,6 +144,16 @@ public class ImportableFile
 	 * @return See above.
 	 */
 	public boolean isFolderAsContainer() { return folderAsContainer; }
+
+	/**
+	 * Returns <code>true</code> if the object is already created,
+	 * <code>false</code> otherwise.
+	 * @return See above.
+	 */
+	public boolean isDatasetCreated()
+	{
+		return dataset.getId() >= 0;
+	}
 	
 	/**
 	 * Sets the component used to notify of the progress.


### PR DESCRIPTION
Attempt to fix https://github.com/ome/omero-insight/issues/94

Check the scenarii described in the issue,

If a user creates a new dataset, the hierarchy will be reloaded at the end of the import similar to what we do for "new from folder".
This means that if the user tries to import in the dataset (to be) "created", another dataset with the same name will be created. Similar to what happen with "new from folder"
This is the less intrusive change I could see

I also notice a space missing in the tooltip of a control

cc @dominikl 
