### PR TITLE
bump packager version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "org.openmicroscopy.publish"
     id "org.openmicroscopy.distribute"
     id "org.openmicroscopy.packager"
-    id "org.openmicroscopy.additional-repositories" version "5.5.1"
+    id "org.openmicroscopy.additional-repositories" version "5.5.2"
 }
 
 group = "org.openmicroscopy"


### PR DESCRIPTION
Test the new version of the plugin.
This means that the pom should no longer contain repository entries

To test:
 * check the pom and make sure it does not contain repository tag
 * travis is green

--exclude

cc @sbesson 