### PR TITLE
Fix bug; Lookupname for omero home dir was overwritten

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
@@ -435,6 +435,7 @@ public class LookupNames
 
     /** Lookup name for the path where the mdeConfig file is located (. = config dir,omero = cuser omero dir) .*/
     public static final String MDE_CONFIG_PATH="omero.client.import.mde.path";
-    public static final String USER_MDE_PATH = "/user/home/omero";
 
+    /** Lookup name for the user mde path **/
+    public static final String USER_MDE_PATH = "/user/home/mde";
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
@@ -169,6 +169,10 @@ public class LookupNames
     /** Field to access the users contained in the group. */
     public static final String USERS_DETAILS = "/users/details";
 
+    /** Field to access the LDAP user information. */
+    @Deprecated
+    public static final String USER_AUTHENTICATION = "/user/authentication";
+
     /** Field indicating if the user is an administrator. */
     public static final String USER_ADMINISTRATOR = "/users/administrator";
 
@@ -276,6 +280,15 @@ public class LookupNames
      */
     public static final String RE_TIMEOUT = "/services/RE/timeout";
 
+    @Deprecated
+    public static final String RE_STACK_BUF_SZ = "/services/RE/stackBufSz";
+
+    @Deprecated
+    public static final String RE_STACK_BLOCK_SZ = "/services/RE/stackBlockSz";
+
+    @Deprecated
+    public static final String RE_MAX_PRE_FETCH = "/services/RE/maxPreFetch";
+
     public static final String CMD_PROCESSOR = "/services/CmdProcessor";
 
     public static final String MONITOR_FACTORY =
@@ -295,6 +308,12 @@ public class LookupNames
 
     /** Field to access the <code>Log service</code> information. */
     public static final String LOGIN = "/services/Login";
+
+    /**
+     * Field to access the <code>Log service configuration</code> information.
+     */
+    @Deprecated
+    public static final String LOGIN_CFG = "/services/Login/config";
 
     /**
      * Field to access the maximum number of tries in order to connect to the

--- a/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
@@ -169,9 +169,6 @@ public class LookupNames
     /** Field to access the users contained in the group. */
     public static final String USERS_DETAILS = "/users/details";
 
-    /** Field to access the LDAP user information. */
-    public static final String USER_AUTHENTICATION = "/user/authentication";
-
     /** Field indicating if the user is an administrator. */
     public static final String USER_ADMINISTRATOR = "/users/administrator";
 
@@ -258,7 +255,7 @@ public class LookupNames
      * <code>Low</code>.
      */
     public static final String THUMBNAIL_FETCH_LOW_SPEED =
-            "/services/Thumbnailing/fetchSz";
+            "/services/Thumbnailing/fetchLowSz";
 
     /**
      * Field to access the Factor by which the maximum number of thumbnails
@@ -279,11 +276,6 @@ public class LookupNames
      */
     public static final String RE_TIMEOUT = "/services/RE/timeout";
 
-    public static final String RE_STACK_BUF_SZ = "/services/RE/stackBufSz";
-    public static final String RE_STACK_BLOCK_SZ = "/services/RE/stackBlockSz";
-
-    public static final String RE_MAX_PRE_FETCH = "/services/RE/maxPreFetch";
-
     public static final String CMD_PROCESSOR = "/services/CmdProcessor";
 
     public static final String MONITOR_FACTORY =
@@ -303,11 +295,6 @@ public class LookupNames
 
     /** Field to access the <code>Log service</code> information. */
     public static final String LOGIN = "/services/Login";
-
-    /**
-     * Field to access the <code>Log service configuration</code> information.
-     */
-    public static final String LOGIN_CFG = "/services/Login/config";
 
     /**
      * Field to access the maximum number of tries in order to connect to the
@@ -355,7 +342,7 @@ public class LookupNames
 
     //For blitz
     /** The value to replace in the FS configuration file. */
-    public static final String FS_HOSTNAME = "/services/FS/defaultDirectory";
+    public static final String FS_HOSTNAME = "/services/FS/hostname";
 
     /** The value to replace in the FS configuration file. */
     public static final String FS_DEFAUL_DIR = "/services/FS/defaultDirectory";

--- a/src/test/java/org/openmicroscopy/shoola/env/LookupNamesTest.java
+++ b/src/test/java/org/openmicroscopy/shoola/env/LookupNamesTest.java
@@ -1,0 +1,27 @@
+package org.openmicroscopy.shoola.env;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+
+public class LookupNamesTest {
+
+    @Test
+    public void testUniqueness() throws Exception {
+        HashSet test = new HashSet<String>();
+        for (Field f : LookupNames.class.getFields()) {
+            if (!Modifier.isStatic(f.getModifiers()))
+                continue;
+            if (!(f.get(null) instanceof String))
+                continue;
+            String value = (String)f.get(null);
+            if (test.contains(value))
+                Assert.fail("Field "+f.getName()+" value '"+value+"' is not unique!");
+            else
+                test.add(value);
+        }
+    }
+}


### PR DESCRIPTION
The `USER_MDE_PATH` LookupName conflicted with the `USER_HOME_OMERO` one, which caused issues https://github.com/ome/omero-insight/issues/154 and https://github.com/ome/omero-insight/issues/153.

**Test**: 
See travis builds of last two commits to check that the units test works. 
Check that Insight still works as expected.
And check that Insight now picks up the correct location for its files again, e.g. the log file, see https://github.com/ome/omero-insight/issues/153 .