### PR TITLE
Bump to Java Gateway 5.6.5.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation("org.jfree:jfreechart:1.0.19")
     implementation("org.swinglabs:swingx:1.6.1")
 
-    implementation("org.openmicroscopy:omero-gateway:5.6.4") {
+    implementation("org.openmicroscopy:omero-gateway:5.6.5") {
         // Conflicts with `net.java.dev.jna`
         exclude group: "com.sun.jna", module: "jna"
     }
@@ -65,4 +65,3 @@ test {
         excludeTestsMatching "TestExecCommandStateTrans.testExecutingCancelled"
     }
 }
-


### PR DESCRIPTION
Bumps to current version of gateway.