### PR TITLE
Ready SNAPSHOT version for next release.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.openmicroscopy"
-version = "5.5.14"
+version = "5.5.15-SNAPSHOT"
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
This commit follows the v5.5.14 tag now pushed to my fork: https://github.com/mtbc/omero-insight/releases/tag/v5.5.14.