### PR TITLE
Prevent potential IllegalComponentStateException

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/util/ui/ScriptingDialog.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/util/ui/ScriptingDialog.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -382,7 +382,8 @@ public class ScriptingDialog
 
             public void mouseReleased(MouseEvent e) {
                 Object src = e.getSource();
-                if (src instanceof Component) {
+                if (src instanceof Component &&
+                        ((Component)src).isVisible()) {
                     Point p = e.getPoint();
                     createOptionMenu().show((Component) src, p.x, p.y);
                 }


### PR DESCRIPTION
Only pop up the dialog when the component is visable. Fixes https://github.com/ome/omero-insight/issues/189 . 

**Test**:
Code review only, don't know how to reproduce the issue, must be very intermittent.

