### PR TITLE
Importdialog closeable

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1845,4 +1845,8 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		showMDEButton.setEnabled(enable);
 	}
 
+	@Override
+	public boolean isClosable() {
+		return false;
+	}
 }

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/ClosableTabbedPane.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/ClosableTabbedPane.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.ClosableTabbedPane 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -168,6 +168,8 @@ public class ClosableTabbedPane
 	{
 		Component c = getComponentAt(index);
 		if (c instanceof ClosableTabbedPaneComponent) {
+			if (!((ClosableTabbedPaneComponent) c).isClosable())
+				return;
 			firePropertyChange(CLOSE_TAB_PROPERTY, null, c);
 		}
 		if (ui instanceof ClosableTabbedPaneUI) {

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/ClosableTabbedPane.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/ClosableTabbedPane.java
@@ -150,6 +150,10 @@ public class ClosableTabbedPane
         int tabCount = getTabCount();
         while (tabCount-- > 0)
             removeTabAt(tabCount);
+        if (getTabCount() > 0)
+        	// in case there are non-closable tabs,
+        	// set the last tab as selected
+			setSelectedIndex(getTabCount()-1);
     }
     
     /**

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/ClosableTabbedPane.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/ClosableTabbedPane.java
@@ -153,7 +153,7 @@ public class ClosableTabbedPane
         if (getTabCount() > 0)
         	// in case there are non-closable tabs,
         	// set the last tab as selected
-			setSelectedIndex(getTabCount()-1);
+        	setSelectedIndex(getTabCount()-1);
     }
     
     /**

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/ClosableTabbedPaneUI.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/ClosableTabbedPaneUI.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.ClosableTabbedPaneUI 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2008 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -161,6 +161,22 @@ class ClosableTabbedPaneUI
 			{
 				super.mousePressed(e);
 				if (e.isPopupTrigger()) {
+					int x = e.getX();
+					int y = e.getY();
+					int tabIndex = -1;
+					int tabCount = tabPane.getTabCount();
+					for (int i = 0; i < tabCount; i++) {
+						if (rects[i].contains(x, y)) {
+							tabIndex = i;
+							break;
+						}
+					}
+
+					Component c = tabPane.getComponentAt(tabIndex);
+					if (c instanceof ClosableTabbedPaneComponent &&
+							!((ClosableTabbedPaneComponent)c).isClosable())
+						return;
+
 					Object source = e.getSource();
 		    		if (source instanceof Component)
 		    			showMenu((Component) source, e.getX(), e.getY());


### PR DESCRIPTION
Prevent to close the ImportDialog tab. Fixes https://github.com/ome/omero-insight/issues/181 .

**Test**:
Right click on the "Select data to import" tab. Without the fix the "Close, Close All, etc." dialog will show up. If you close the tab via this dialog, close the importer dialog and open it again, it'll crash with the IllegalComponentStateException. With the fix you shouldn't have the possibility to close this tab.
![Screen Shot 2021-01-26 at 15 28 02](https://user-images.githubusercontent.com/6575139/105865842-3b31ba00-5feb-11eb-86bf-24ac70e8bdde.png)
