### PR TITLE
Pass through commandline arguments

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/Main.java
+++ b/src/main/java/org/openmicroscopy/shoola/Main.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.Main
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -29,6 +29,10 @@ package org.openmicroscopy.shoola;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.env.Container;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /** 
  * Application entry point.
@@ -64,9 +68,11 @@ public class Main
 	{
 		String homeDir = "";
 		String configFile = null;//Container.CONFIG_FILE;
-		if (args.length > 0) configFile = args[0];
-		if (args.length > 1) homeDir = args[1];
-		Container.startup(homeDir, configFile);
+		List<String> addArgs = Arrays.stream(args).filter(a -> a.startsWith("--")).collect(Collectors.toList());
+		List<String> posArgs = Arrays.stream(args).filter(a -> !a.startsWith("--")).collect(Collectors.toList());
+		if (posArgs.size() > 0) configFile = posArgs.get(0);
+		if (posArgs.size() > 1) homeDir = posArgs.get(1);
+		Container.startup(homeDir, configFile, addArgs);
 	}
 	
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/config/Registry.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/config/Registry.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.config.Registry
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -40,6 +40,9 @@ import omero.gateway.Gateway;
 
 import org.openmicroscopy.shoola.env.ui.TaskBar;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
+
+import java.util.Collection;
+import java.util.Set;
 
 /**
  * Declares the operations to be used to access configuration entries and 
@@ -167,6 +170,22 @@ public interface Registry
      *          supported {@link DataServicesView} interfaces.
      */
     public DataServicesView getDataServicesView(Class<?> view);
-    
+
+	/**
+	 * Get the reference to the Gateway
+	 * @return See above.
+	 */
     public Gateway getGateway();
+
+	/**
+	 * Get additional command line arguments
+	 * @return See above.
+	 */
+	public Collection<String> getCmdLineArgs();
+
+	/**
+	 * Add additional command line arguments
+	 * @param args The arguments
+	 */
+	public void addCmdLineArgs(Collection<String> args);
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/config/RegistryImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/config/RegistryImpl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.config.RegistryImpl
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -24,7 +24,12 @@
 package org.openmicroscopy.shoola.env.config;
 
 //Java imports
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 //Third-party libraries
 
@@ -96,8 +101,12 @@ class RegistryImpl
     
     /** Reference to the Administration service. */
     private AdminService			admin;
-    
+
+    /** Reference to the Gateway */
     private Gateway gateway;
+
+	/** Additional command line arguments */
+	private Set<String> cmdLineArgs = new HashSet<>();
     
     /* may be constructed only by classes in this package */
     RegistryImpl() { }
@@ -248,12 +257,35 @@ class RegistryImpl
      */
     void setOS(OmeroDataService os) { this.os = os; }
 
-    public Gateway getGateway() {
+	/**
+	 * Get the reference to the Gateway
+	 * @return See above.
+	 */
+	public Gateway getGateway() {
         return gateway;
     }
 
-    void setGateway(Gateway gateway) {
+	/**
+	 * Set reference to the Gateway
+	 * @param gateway The Gateway
+	 */
+	void setGateway(Gateway gateway) {
         this.gateway = gateway;
     }
-    
+
+	/**
+	 * Get additional command line arguments
+	 * @return See above.
+	 */
+	public Collection<String> getCmdLineArgs() {
+		return cmdLineArgs;
+	}
+
+	/**
+	 * Add additional command line arguments
+	 * @param args The arguments
+	 */
+	public void addCmdLineArgs(Collection<String> args) {
+		this.cmdLineArgs.addAll(args);
+	}
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/login/UserCredentials.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/login/UserCredentials.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -20,7 +20,12 @@
  */
 package org.openmicroscopy.shoola.env.data.login;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -73,7 +78,10 @@ public class UserCredentials extends LoginCredentials
 	 * This map should only be used to change ownership status.
 	 */
 	private Map<GroupData, Boolean> groupsOwner;
-	
+
+	/** Additional command line arguments */
+	private Set<String> cmdLineArgs = new HashSet<>();
+
     /** 
      * Controls if the passed speed index is supported.
      * 
@@ -303,5 +311,33 @@ public class UserCredentials extends LoginCredentials
 				buf.append('*');
         return buf.toString();
     }
-    
+
+	/**
+	 * Add additional command line args as "some.arg=somevalue"
+	 * or "--some.arg=somevalue"
+	 * @param args The arguments
+	 */
+	public void addCmdLineArgs(Collection<String> args) {
+    	this.cmdLineArgs.addAll(args);
+	}
+
+	@Override
+	public List<String> getArguments() {
+		// Args login has precedence. By overriding this method
+		// and making sure it's not null/empty the gateway will
+		// use this argument list for login and additional command
+		// line arguments can be passed through.
+		List<String> res = new ArrayList<>();
+		res.add("--omero.user="+getUser().getUsername());
+		res.add("--omero.pass="+getUser().getPassword());
+		res.add("--omero.host="+getServer().getHost());
+		res.add("--omero.port="+getServer().getPort());
+		for (String arg : cmdLineArgs) {
+			if (arg.startsWith("--"))
+				res.add(arg);
+			else
+				res.add("--"+arg);
+		}
+		return res;
+	}
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/login/ScreenLogin.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/login/ScreenLogin.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -61,6 +61,7 @@ import javax.swing.JToolBar;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
+import org.openmicroscopy.shoola.env.Container;
 import org.openmicroscopy.shoola.env.config.OMEROInfo;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.login.UserCredentials;
@@ -263,6 +264,7 @@ public class ScreenLogin
 		try {
 			UserCredentials lc = new UserCredentials(usr, psw, s, speedIndex);
 			lc.setEncrypted(encrypted);
+			lc.addCmdLineArgs(registry.getCmdLineArgs());
 			setUserName(usr);
 			setEncrypted();
 			setControlsEnabled(false);

--- a/src/test/java/org/openmicroscopy/shoola/env/config/NullRegistry.java
+++ b/src/test/java/org/openmicroscopy/shoola/env/config/NullRegistry.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.config.NullRegistry
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -42,6 +42,8 @@ import omero.log.Logger;
 import org.openmicroscopy.shoola.env.ui.TaskBar;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 
+import java.util.Collection;
+
 /** 
  * No-op implementation.
  *
@@ -73,5 +75,7 @@ public class NullRegistry
     public AdminService getAdminService() { return null; }
 	public String lookupRemote(String name) { return null; }
     public Gateway getGateway() { return null;}
-    
+    public Collection<String> getCmdLineArgs() { return null; }
+    public void addCmdLineArgs(Collection<String> args) {}
+
 }


### PR DESCRIPTION
Allows to pass through command line arguments to `omero.client`, e.g. `--Ice.HTTPProxyHost=PROXY --Ice.HTTPProxyPort=PORT`. Fixes https://github.com/ome/omero-insight/issues/190 . I'm still not sure how to pass through an `ICE_CONFIG` environment variable. But afaik this shouldn't be necessary as you can just use the command line arguments with this PR.

**Test**:
To check if the arguments are taken into account just use something like `--Ice.HTTPProxyHost=1.2.3.4` and you shouldn't be able to connect. Remove it again and you can connect again.
