### PR TITLE
Also catch NPEs in ThumbnailLoader

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -216,7 +216,7 @@ public class ThumbnailLoader extends BatchCallTree {
                         try {
                             store = getThumbnailStore(pxd);
                             handleBatchCall(store, pxd, userId);
-                        } catch (DSAccessException | ServerError e) {
+                        } catch (Exception e) {
                             currentThumbnail = new ThumbnailData(pxd.getImage().getId(),
                                     getErrorIcon(), userId, false);
 


### PR DESCRIPTION
Catch all exceptions and use the error icon as thumbnails. Should fix https://github.com/ome/omero-insight/issues/192 (although I don't know why the Image's Pixeldata was `null` in that case).
