### PR TITLE
Fix build artifacts

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -66,8 +66,9 @@ jobs:
       - name: Build Dmg
         if: startsWith(matrix.os, 'macos') && startsWith(github.ref, 'refs/tags') && matrix.java == '1.8'
         run: |
-          brew cask install zulu8
-          export JAVA_HOME='/Library/Java/JavaVirtualMachines/zulu-8.jdk/Contents/Home'
+          brew tap bell-sw/liberica
+          brew install --cask liberica-jdk8-full
+          export JAVA_HOME='/Library/Java/JavaVirtualMachines/liberica-jdk-8-full.jdk/Contents/Home'
           export PATH=$JAVA_HOME/bin:$PATH
           ./gradlew packageApplicationDmg
           ./gradlew packageImporterApplicationDmg

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -66,9 +66,7 @@ jobs:
       - name: Build Dmg
         if: startsWith(matrix.os, 'macos') && startsWith(github.ref, 'refs/tags') && startsWith(matrix.java, '8')
         run: |
-          brew tap bell-sw/liberica
-          brew install --cask liberica-jdk8-full
-          export JAVA_HOME='/Library/Java/JavaVirtualMachines/liberica-jdk-8-full.jdk/Contents/Home'
+          export JAVA_HOME='/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home'
           export PATH=$JAVA_HOME/bin:$PATH
           ./gradlew packageApplicationDmg
           ./gradlew packageImporterApplicationDmg

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [1.8, 11]
+        java: [8.0.275, 11]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
@@ -43,7 +43,7 @@ jobs:
         shell: bash
         run: echo "$WIX\\bin" >> $GITHUB_PATH
       - name: Build Executable
-        if: startsWith(matrix.os, 'windows') && startsWith(github.ref, 'refs/tags') && matrix.java == '1.8'
+        if: startsWith(matrix.os, 'windows') && startsWith(github.ref, 'refs/tags') && startsWith(matrix.java, '8')
         run: |
           choco uninstall innosetup
           choco install innosetup --version=5.6.1
@@ -52,7 +52,7 @@ jobs:
           ./gradlew packageApplicationMsi
           ./gradlew packageImporterApplicationMsi
       - name: Check MSI
-        if: startsWith(matrix.os, 'windows') && startsWith(github.ref, 'refs/tags') && matrix.java == '1.8'
+        if: startsWith(matrix.os, 'windows') && startsWith(github.ref, 'refs/tags') && startsWith(matrix.java, '8')
         run: |
           msi=(`find build/packaged/installImporterDist/bundles -maxdepth 1 -name "*.msi"`)
           if [ ${#msi[@]} == 0 ]; then
@@ -64,7 +64,7 @@ jobs:
           fi
         shell: bash
       - name: Build Dmg
-        if: startsWith(matrix.os, 'macos') && startsWith(github.ref, 'refs/tags') && matrix.java == '1.8'
+        if: startsWith(matrix.os, 'macos') && startsWith(github.ref, 'refs/tags') && startsWith(matrix.java, '8')
         run: |
           brew tap bell-sw/liberica
           brew install --cask liberica-jdk8-full
@@ -73,28 +73,28 @@ jobs:
           ./gradlew packageApplicationDmg
           ./gradlew packageImporterApplicationDmg
       - name: Upload zip and jar
-        if: startsWith(matrix.os, 'ubuntu') && startsWith(github.ref, 'refs/tags') && matrix.java == '1.8'
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(github.ref, 'refs/tags') && startsWith(matrix.java, '8')
         uses: actions/upload-artifact@v2
         with:
             name: artifacts
             path: build/distributions/OMERO*
             if-no-files-found: error
       - name: Upload jar
-        if: startsWith(matrix.os, 'ubuntu') && startsWith(github.ref, 'refs/tags') && matrix.java == '1.8'
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(github.ref, 'refs/tags') && startsWith(matrix.java, '8')
         uses: actions/upload-artifact@v2
         with:
           name: artifacts
           path: build/libs/omero_*
           if-no-files-found: error
       - name: Upload insight artifacts
-        if: startsWith(matrix.os, 'ubuntu') != true && startsWith(github.ref, 'refs/tags') && matrix.java == '1.8'
+        if: startsWith(matrix.os, 'ubuntu') != true && startsWith(github.ref, 'refs/tags') && startsWith(matrix.java, '8')
         uses: actions/upload-artifact@v2
         with:
           name: artifacts
           path: build/packaged/main/bundles/*
           if-no-files-found: error
       - name: Upload importer artifacts
-        if: startsWith(matrix.os, 'ubuntu') != true && startsWith(github.ref, 'refs/tags') && matrix.java == '1.8'
+        if: startsWith(matrix.os, 'ubuntu') != true && startsWith(github.ref, 'refs/tags') && startsWith(matrix.java, '8')
         uses: actions/upload-artifact@v2
         with:
           name: artifacts

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 
   ### OSX
 
-  If you are using [Homebrew](https://brew.sh/), you can install, for example, [OpenJDK 8](https://www.azul.com/downloads/zulu/)
+  If you are using [Homebrew](https://brew.sh/), you can install, for example, [OpenJDK 8](https://bell-sw.com/pages/downloads/)
   which comes bundled with JavaFX.
   To install run:
 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,6 @@
 
       scoop install zulufx8
 
-  #### Chocolatey:
-
-      choco install zulu8
-
   #### Manually:
 
   To set up a build environment with Windows without using a package manager such as [Scoop](https://scoop.sh) or

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@
   which comes bundled with JavaFX.
   To install run:
 
-      brew cask install zulu8
+      brew tap bell-sw/liberica
+      brew install --cask liberica-jdk8-full
 
   ### Windows
 


### PR DESCRIPTION
This PR 
* Windows: caps the java 8 version to ``8.0.275``, the version installed is now ``8.0.282`` and it no longer contains the ``javapackager`` that we use to build the ``.exe`` and ``.msi``. 
* Mac: ``brew cask`` has been removed and we now need to use ``brew install --cask``. Unfortunately the cask ``zulu8`` is no longer available. ``adoptopenjdk 8.0.275`` allows us to build the dmg.

The changes in this PR were used to build https://github.com/jburel/omero-insight/releases/tag/v5.5.15 see
https://github.com/jburel/omero-insight/actions/runs/530995148