### PR TITLE
Don't create a directory for downloaded multifile image

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
@@ -294,7 +294,7 @@ public interface Editor
 	 *      	  Put multifile images into own directories
      */
     public void downloadOriginal(String path, boolean override,
-								 boolean createMFIDirectory);
+					boolean createMFIDirectory);
 	
 	/**
 	 * Sets the parent of the root object. This will be taken into account

--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/Editor.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -290,8 +290,11 @@ public interface Editor
      * @param override
      *            Flag indicating to override the existing file if it exists,
      *            <code>false</code> otherwise.
+	 * @param createMFIDirectory
+	 *      	  Put multifile images into own directories
      */
-    public void downloadOriginal(String path, boolean override);
+    public void downloadOriginal(String path, boolean override,
+								 boolean createMFIDirectory);
 	
 	/**
 	 * Sets the parent of the root object. This will be taken into account

--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorComponent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -635,11 +635,11 @@ class EditorComponent
      * 
      * @see Editor#downloadOriginal(String, boolean)
      */
-    public void downloadOriginal(String path, boolean override) {
+    public void downloadOriginal(String path, boolean override, boolean createMFIDirectory) {
         if (CommonsLangUtils.isEmpty(path))
             return;
 
-        model.downloadOriginal(path, override);
+        model.downloadOriginal(path, override, createMFIDirectory);
     }
 
 	/** 

--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorControl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -302,13 +302,14 @@ class EditorControl
         chooser.setTitleIcon(icons.getIcon(IconManager.DOWNLOAD_48));
         chooser.setApproveButtonText(FileChooser.DOWNLOAD_TEXT);
         chooser.setCheckOverride(true);
+		chooser.enableMFICheckbox(true);
         chooser.addPropertyChangeListener(new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent evt) {
                 String name = evt.getPropertyName();
                 FileChooser src = (FileChooser) evt.getSource();
                 if (FileChooser.APPROVE_SELECTION_PROPERTY.equals(name)) {
                     String path = (String) evt.getNewValue();
-                    model.downloadOriginal(path, src.isOverride());
+                    model.downloadOriginal(path, src.isOverride(), src.createMFIDirectory());
                 }
             }
         });

--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -3096,8 +3096,11 @@ class EditorModel
      * @param override
      *            Flag indicating to override the existing file if it exists,
      *            <code>false</code> otherwise.
+	 * @param createMFIDirectory
+	 *            Put multifile images into own directories
+	 *
      */
-    void downloadOriginal(String path, boolean override) {
+    void downloadOriginal(String path, boolean override, boolean createMFIDirectory) {
         if (!(refObject instanceof ImageData || refObject instanceof PlateData
                 || refObject instanceof WellData
                 || refObject instanceof WellSampleData || refObject instanceof PlateAcquisitionData))
@@ -3167,6 +3170,7 @@ class EditorModel
             SecurityContext ctx = getSecurityContext();
             p = new DownloadArchivedActivityParam(new File(path), images, icon);
             p.setOverride(override);
+            p.setCreateMFIDirectory(createMFIDirectory);
             p.setZip(false);
             p.setKeepOriginalPaths(true);
             un.notifyActivity(ctx, p);

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2020 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -3143,8 +3143,6 @@ class OMEROGateway
 		String folderPath = null;
 		folderPath = file.getAbsolutePath();
 		Iterator<Entry<OriginalFile, Fileset>> entries = values.entrySet().iterator();
-
-		Map<Fileset, String> filesetPaths = new HashMap<Fileset, String>();
 		
 		while (entries.hasNext()) {
 		    Entry<OriginalFile, Fileset> entry = entries.next();
@@ -3154,25 +3152,10 @@ class OMEROGateway
 			
             String path = null;
             if (keepOriginalPaths && set != null && set.sizeOfUsedFiles() > 1) {
-                // this will store multi file images within a subdirectory with
-                // the same name as the main image file
-                path = filesetPaths.get(set);
-                if (path == null) {
-                    path = folderPath.endsWith("/") ? folderPath : folderPath + "/";
-                    String imgFilename = set.getFilesetEntry(0).getOriginalFile()
-                            .getName().getValue();
-                    path += imgFilename;
-                    path = generateUniquePathname(path, false);
-                    // path should now be in the form
-                    // DOWNLOAD_FOLDER/IMAGE_NAME[(N)]
-                    // where N is a consecutive number if the folder IMAGE_NAME
-                    // already exists
-                    filesetPaths.put(set, path);
-                }
                 String repoPath = set.getTemplatePrefix().getValue();
-                path = path +"/"+ (of.getPath().getValue().replace(repoPath, ""));
+                path = folderPath +"/"+ (of.getPath().getValue().replace(repoPath, ""));
                 // path should now be in the form
-                // DOWNLOAD_FOLDER/IMAGE_NAME[(N)]/X/Y/Z
+                // DOWNLOAD_FOLDER/X/Y/Z
                 // where X, Y, Z are image specific subdirectories
                 // for the single image/data files
                 File origPath = new File(path);

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataService.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataService.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -299,7 +299,8 @@ public interface OmeroDataService
 	 * retrieve data from OMERO service.
 	 */
 	public Map<Boolean, Object> getArchivedImage(SecurityContext ctx,
-			File location, long imageID, boolean keepOriginalPath)
+			File location, long imageID, boolean keepOriginalPath,
+			boolean createMFIDirectory)
 		throws DSOutOfServiceException, DSAccessException;
 
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -497,13 +497,14 @@ class OmeroDataServiceImpl
 	 * @see OmeroDataService#getArchivedFiles(SecurityContext, File, long, boolean)
 	 */
 	public Map<Boolean, Object> getArchivedImage(SecurityContext ctx,
-			File file, long imageID, boolean keepOriginalPath)
+			File file, long imageID, boolean keepOriginalPath,
+			boolean createMFIDirectory)
 		throws DSOutOfServiceException, DSAccessException
 	{
 		context.getLogger().debug(this, file.getAbsolutePath());
 		//Check the image is archived.
 		ImageData image = gateway.getImage(ctx, imageID, null);
-		return gateway.getArchivedFiles(ctx, file, image, keepOriginalPath);
+		return gateway.getArchivedFiles(ctx, file, image, keepOriginalPath, createMFIDirectory);
 	}
 
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/env/data/model/DownloadArchivedActivityParam.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/model/DownloadArchivedActivityParam.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -51,6 +51,9 @@ public class DownloadArchivedActivityParam
     /** Flag indicating to override or not the files when saving.*/
     private boolean override;
 
+    /** Flag indicating to put multifile images into own directories.*/
+    private boolean createMFIDirectory;
+
     /** Flag for zipping the downloaded images */
     private boolean zip = false;
     
@@ -71,6 +74,7 @@ public class DownloadArchivedActivityParam
     	this.images = images;
     	this.icon = icon;
     	this.override = false;
+    	this.createMFIDirectory = false;
     }
 
     /**
@@ -82,12 +86,29 @@ public class DownloadArchivedActivityParam
     public void setOverride(boolean override) { this.override = override; }
 
     /**
+     * Sets to <code>true</code> to override the files when saving,
+     * <code>false</code> otherwise. Default is <code>false</code>.
+     *
+     * @param createMFIDirectory The value to set.
+     */
+    public void setCreateMFIDirectory(boolean createMFIDirectory) {
+        this.createMFIDirectory = createMFIDirectory;
+    }
+
+    /**
      * Returns <code>true</code> to override the files when saving,
      * <code>false</code> otherwise. Default is <code>false</code>.
      *
      * @return See above.
      */
     public boolean isOverride() { return override; }
+
+    /**
+     * Returns <code>true</code> to put multifile images into own directories
+     *
+     * @return See above.
+     */
+    public boolean createMFIDirectory() { return createMFIDirectory; }
 
     /**
      * Returns the icon.

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/MetadataHandlerView.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -308,7 +308,7 @@ public interface MetadataHandlerView
 	 */
 	public CallHandle loadArchivedImage(SecurityContext ctx, List<DataObject> objects,
 		File location, boolean override, boolean zip, boolean keepOriginalPaths,
-		AgentEventListener observer);
+		boolean createMFIDirectory, AgentEventListener observer);
     
 	/**
 	 * Filters by annotation.

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/MetadataHandlerViewImpl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -247,14 +247,14 @@ class MetadataHandlerViewImpl
      * Implemented as specified by the view interface.
      * 
      * @see MetadataHandlerView#loadArchivedImage(SecurityContext , List, File ,
-     *      boolean , boolean , boolean , AgentEventListener )
+     *      boolean , boolean , boolean , boolean, AgentEventListener )
      */
     public CallHandle loadArchivedImage(SecurityContext ctx,
             List<DataObject> objects, File location,
             boolean override, boolean zip, boolean keepOriginalPaths,
-            AgentEventListener observer) {
+            boolean createMFIDirectory, AgentEventListener observer) {
         BatchCallTree cmd = new ArchivedImageLoader(ctx, objects, location,
-                override, zip, keepOriginalPaths);
+                override, zip, createMFIDirectory, keepOriginalPaths);
         return cmd.exec(observer);
     }
     

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ArchivedImageLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ArchivedImageLoader.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.views.calls.ArchivedImageLoader 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -74,7 +74,9 @@ public class ArchivedImageLoader
     
     /** Flag for preserving the original folder structure */
     private boolean keepOriginalPaths = false;
-    
+
+    /** Flag indicating to put multifile images into own directories.*/
+    private boolean createMFIDirectory = false;
     /**
      * Copies the specified file to the folder.
      * 
@@ -171,7 +173,8 @@ public class ArchivedImageLoader
                     
                     for (Long imageID : imageIDs) {
                         Map<Boolean, Object> r = os.getArchivedImage(ctx,
-                                tmpFolder, imageID, keepOriginalPaths);
+                                tmpFolder, imageID, keepOriginalPaths,
+                                createMFIDirectory);
                         files.addAll((List<File>) r.get(Boolean.TRUE));
                     }
                     
@@ -253,13 +256,15 @@ public class ArchivedImageLoader
      * @param keepOriginalPaths Pass <code>true</code> to preserve the original folder structure
      */
     public ArchivedImageLoader(SecurityContext ctx, List<DataObject> objects,
-            File folderPath, boolean override, boolean zip, boolean keepOriginalPaths)
+            File folderPath, boolean override, boolean zip, boolean keepOriginalPaths,
+            boolean createMFIDirectory)
     {
         if (CollectionUtils.isEmpty(objects))
              throw new IllegalArgumentException("No objects provided.");
         this.override = override;
         this.zip = zip;
         this.keepOriginalPaths = keepOriginalPaths;
+        this.createMFIDirectory = createMFIDirectory;
         loadCall = makeBatchCall(ctx, objects, folderPath);
     }
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/ArchivedLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/ArchivedLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -68,7 +68,10 @@ public class ArchivedLoader
     
     /** Flag for preserving the original folder structure */
     private boolean keepOriginalPaths = true;
-    
+
+    /** Flag indicating to put multifile images into own directories.*/
+    private boolean createMFIDirectory = false;
+
     /**
      * Notifies that an error occurred.
      * @see UserNotifierLoader#onException(String, Throwable)
@@ -92,11 +95,13 @@ public class ArchivedLoader
      *                 exists, <code>false</code> otherwise.
      * @param zip Pass <code>true</code> to create a zip file
      * @param keepOriginalPaths Pass <code>true</code> to preserve the original folder structure
+     * @param createMFIDirectory  Flag indicating to put multifile images into own directories
      * @param activity The activity associated to this loader.
      */
 	public ArchivedLoader(UserNotifier viewer, Registry registry,
 			SecurityContext ctx, List<DataObject> objects, File file,
-			boolean override, boolean zip, boolean keepOriginalPaths, ActivityComponent activity)
+			boolean override, boolean zip, boolean keepOriginalPaths, boolean createMFIDirectory,
+            ActivityComponent activity)
 	{
 		super(viewer, registry, ctx, activity);
 		if (objects == null)
@@ -106,6 +111,7 @@ public class ArchivedLoader
 		this.override = override;
 		this.zip = zip;
 		this.keepOriginalPaths = keepOriginalPaths;
+		this.createMFIDirectory = createMFIDirectory;
 	}
     
     /**
@@ -118,7 +124,7 @@ public class ArchivedLoader
             return;
 
         handle = mhView.loadArchivedImage(ctx, objects, file, override, zip,
-                keepOriginalPaths, this);
+                keepOriginalPaths, createMFIDirectory, this);
     }
 
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/DownloadArchivedActivity.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/DownloadArchivedActivity.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.DownloadArchivedActivity 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -102,7 +102,7 @@ public class DownloadArchivedActivity
 	    File f = parameters.getLocation();
 		loader = new ArchivedLoader(viewer, registry, ctx,
 		        parameters.getImages(), f, parameters.isOverride(), parameters.isZip(), 
-		        parameters.isKeepOriginalPaths(), this);
+		        parameters.isKeepOriginalPaths(), parameters.createMFIDirectory(), this);
 		return loader;
 	}
 

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -125,7 +125,7 @@ public class OpenObjectLoader
     		    objects.add(image);
     		    f = new File(folderPath);
     		    handle = mhView.loadArchivedImage(ctx, objects, f, false, false,
-    	                false, this);
+    	                false, false,this);
     		} else {
     		    String name = image.getName();
                 name += image.getName();

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/FileChooser.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/FileChooser.java
@@ -25,10 +25,14 @@ package org.openmicroscopy.shoola.util.ui.filechooser;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.regex.Pattern;
-import javax.swing.*;
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
 import javax.swing.filechooser.FileFilter;
 
 import org.apache.commons.collections4.CollectionUtils;

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/FileChooser.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/FileChooser.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.filechooser.FileSaver 
  *
   *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -25,14 +25,10 @@ package org.openmicroscopy.shoola.util.ui.filechooser;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.regex.Pattern;
-import javax.swing.Icon;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JDialog;
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
+import javax.swing.*;
 import javax.swing.filechooser.FileFilter;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -429,6 +425,14 @@ public class FileChooser
     }
 
     /**
+     * Checks if the mfiDirCheckbox is checked.
+     * @return See above.
+     */
+    public boolean createMFIDirectory() {
+        return uiDelegate.createMFIDirectory();
+    }
+
+    /**
      * Sets the name of the file to save.
      * 
      * @param name The name to set.
@@ -550,6 +554,9 @@ public class FileChooser
         uiDelegate.setApproveButtonText(text);
     }
 
+    public void enableMFICheckbox(boolean enable) {
+        uiDelegate.enableMFICheckbox(enable);
+    }
     /**
      * Sets the text displayed in the tool tip of the <code>Approve</code>
      * button.

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/FileSaverUI.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/FileSaverUI.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.filechooser.FileSaverUI 
  *
   *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -128,6 +128,8 @@ class FileSaverUI
 	 */
 	private JButton						newFolderButton;
 
+	private JCheckBox mfiDirCheckbox;
+
 	/** The panel hosting the buttons. */
 	private JPanel						buttonPanel;
 	
@@ -159,6 +161,11 @@ class FileSaverUI
     			UIUtilities.formatToolTipText("Create a new folder"));
 		newFolderButton.addActionListener(this);
 		newFolderButton.setActionCommand(""+NEW_FOLDER);
+		mfiDirCheckbox = new JCheckBox("Create directory");
+		mfiDirCheckbox.setToolTipText(UIUtilities.formatToolTipText("Put multifile images" +
+				"into a directory."));
+		mfiDirCheckbox.setSelected(true);
+		mfiDirCheckbox.setVisible(false);
 		approveButton = new JButton();
 		switch (model.getChooserType()) {
 			case FileChooser.SAVE:
@@ -246,6 +253,8 @@ class FileSaverUI
     	if (type != FileChooser.LOAD && type != FileChooser.IMPORT) {
     		controls.add(Box.createRigidArea(new Dimension(20, 5)));
         	controls.add(newFolderButton);
+			controls.add(Box.createRigidArea(new Dimension(20, 5)));
+			controls.add(mfiDirCheckbox);
     	}
     	
     	JPanel p = UIUtilities.buildComponentPanelRight(buttonPanel);
@@ -349,6 +358,22 @@ class FileSaverUI
 	{
 		chooser.setOriginalName(file.getName());
 		chooser.setSelectedFile(file);
+	}
+
+	/**
+	 * Checks if the mfiDirCheckbox is checked.
+	 * @return See above.
+	 */
+	boolean createMFIDirectory() {
+		return mfiDirCheckbox.isSelected();
+	}
+
+	void enableMFICheckbox(boolean enable) {
+		if (enable) {
+			mfiDirCheckbox.setVisible(true);
+		} else {
+			mfiDirCheckbox.setVisible(false);
+		}
 	}
 
 	/**

--- a/src/test/java/org/openmicroscopy/shoola/env/data/NullOmeroPojoService.java
+++ b/src/test/java/org/openmicroscopy/shoola/env/data/NullOmeroPojoService.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -190,7 +190,7 @@ public class NullOmeroPojoService
      * @see OmeroDataService#getArchivedFiles(String, long)
      */
 	public Map getArchivedImage(SecurityContext ctx, File location,
-			long pixelsID, boolean keepOriginalPath) 
+			long pixelsID, boolean keepOriginalPath, boolean createMFIDirectory)
 		throws DSOutOfServiceException, DSAccessException
 	{
 		return null;


### PR DESCRIPTION
Fixes https://github.com/ome/omero-insight/issues/188 by simply not creating a directory for a multifile image in first place, following the suggestion from @CellKai . Makes sense imo, or was there a specific reason for downloading the files of an image into a separate directory @jburel ?

