### PR TITLE
Escape ice special characters for login

### DIFF
--- a/src/config/container.xml
+++ b/src/config/container.xml
@@ -189,6 +189,8 @@
     <entry name="omero.client.import.mde.enabled" type="boolean">false</entry>
     <!-- mde config file location (. for in config dir; omero for local user omero dir) -->
     <entry name="omero.client.import.mde.path">.</entry>
+    <!-- escape ice special characters, see https://doc.zeroc.com/ice/3.6/properties-and-configuration/configuration-file-syntax -->
+    <entry name="omero.client.login_escape_characters">#=\s\\</entry>
   </services>
 
   <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/config/containerImporter.xml
+++ b/src/config/containerImporter.xml
@@ -170,6 +170,8 @@
     <entry name="omero.client.import.mde.enabled" type="boolean">false</entry>
     <!-- mde config file location (. for in config dir; omero for local user omero dir) -->
     <entry name="omero.client.import.mde.path">.</entry>
+    <!-- escape ice special characters, see https://doc.zeroc.com/ice/3.6/properties-and-configuration/configuration-file-syntax -->
+    <entry name="omero.client.login_escape_characters">#=\s\\</entry>
   </services>
 
   <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/LookupNames.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -444,4 +444,7 @@ public class LookupNames
 
     /** Lookup name for the user mde path **/
     public static final String USER_MDE_PATH = "/user/home/mde";
+
+    /** Lookup name for characters which need to escaped for the login username / password */
+    public static final String LOGIN_ESCAPE_CHARACTERS="omero.client.login_escape_characters";
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/login/UserCredentials.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/login/UserCredentials.java
@@ -22,7 +22,6 @@ package org.openmicroscopy.shoola.env.data.login;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -81,6 +80,9 @@ public class UserCredentials extends LoginCredentials
 
 	/** Additional command line arguments */
 	private Set<String> cmdLineArgs = new HashSet<>();
+
+	/** Characters which need to be escaped for the login username / password */
+	private String escapeChars = null;
 
     /** 
      * Controls if the passed speed index is supported.
@@ -328,8 +330,8 @@ public class UserCredentials extends LoginCredentials
 		// use this argument list for login and additional command
 		// line arguments can be passed through.
 		List<String> res = new ArrayList<>();
-		res.add("--omero.user="+getUser().getUsername());
-		res.add("--omero.pass="+getUser().getPassword());
+		res.add("--omero.user="+escape(getUser().getUsername()));
+		res.add("--omero.pass="+escape(getUser().getPassword()));
 		res.add("--omero.host="+getServer().getHost());
 		res.add("--omero.port="+getServer().getPort());
 		for (String arg : cmdLineArgs) {
@@ -339,5 +341,25 @@ public class UserCredentials extends LoginCredentials
 				res.add("--"+arg);
 		}
 		return res;
+	}
+
+	/**
+	 * Set characters which need to escaped for the login username / password
+	 * @param escapeChars See above.
+	 */
+	public void setEscapeChars(String escapeChars) {
+		this.escapeChars = escapeChars;
+	}
+
+	/**
+	 * Escape characters, if escapeChars is set.
+	 * @param arg The string to escape
+	 * @return See above.
+	 */
+	private String escape(String arg) {
+		if (escapeChars != null && escapeChars.length()>0) {
+			return arg.replaceAll("([" + escapeChars + "])", "\\\\$1");
+		}
+		return arg;
 	}
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/login/ScreenLogin.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/login/ScreenLogin.java
@@ -61,7 +61,7 @@ import javax.swing.JToolBar;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
-import org.openmicroscopy.shoola.env.Container;
+import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.config.OMEROInfo;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.login.UserCredentials;
@@ -263,6 +263,7 @@ public class ScreenLogin
 		setControlsEnabled(false);
 		try {
 			UserCredentials lc = new UserCredentials(usr, psw, s, speedIndex);
+			lc.setEscapeChars((String) registry.lookup(LookupNames.LOGIN_ESCAPE_CHARACTERS));
 			lc.setEncrypted(encrypted);
 			lc.addCmdLineArgs(registry.getCmdLineArgs());
 			setUserName(usr);


### PR DESCRIPTION
This should properly fix https://github.com/ome/omero-insight/issues/224 .

Test: Use 'pwtest' user with password ' test' (leading space!) and check the logs that the first login attempt works.
