### PR TITLE
MDE enabled in the standard configuration of importer

### DIFF
--- a/src/config/container.xml
+++ b/src/config/container.xml
@@ -186,9 +186,9 @@
     <entry name="omero.client.import.offline.url">http://localhost:8000/ome/import</entry>
     <entry name="omero.client.import.offline.enabled" type="boolean">false</entry>
     <!-- mde on/off -->
-    <entry name="omero.client.import.mde.enabled" type="boolean">false</entry>
+    <entry name="omero.client.import.mde.enabled" type="boolean">true</entry>
     <!-- mde config file location (. for in config dir; omero for local user omero dir) -->
-    <entry name="omero.client.import.mde.path">.</entry>
+    <entry name="omero.client.import.mde.path">omero</entry>
   </services>
 
   <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/config/containerImporter.xml
+++ b/src/config/containerImporter.xml
@@ -167,9 +167,9 @@
     <entry name="/services/DEBUGGER/postTimeout" type="integer">2000</entry>
     <entry name="/services/DEBUGGER/emailAddress">qa@openmicroscopy.org.uk</entry>
     <!-- mde on/off -->
-    <entry name="omero.client.import.mde.enabled" type="boolean">false</entry>
+    <entry name="omero.client.import.mde.enabled" type="boolean">true</entry>
     <!-- mde config file location (. for in config dir; omero for local user omero dir) -->
-    <entry name="omero.client.import.mde.path">.</entry>
+    <entry name="omero.client.import.mde.path">omero</entry>
   </services>
 
   <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
For easier use of the OMERO.mde also for users who download the OMERO.insight as an `exe` . Default location for a `mdeConfiguration` file is the local user omero directory.