### PR TITLE
enable use of OMERO.importer with read-only server

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/ImporterAgent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/ImporterAgent.java
@@ -519,4 +519,16 @@ public class ImporterAgent
         }
     }
 
+    /**
+     * Returns <code>true</code> data objects can be created,
+     * <code>false</code> otherwise. This will be <code>false</code> if the
+     * server is for example read-only.
+     *
+     * @return See above.
+     */
+    public static boolean canCreate() {
+        Boolean b = (Boolean) registry.lookup(LookupNames.CAN_CREATE);
+        return b.booleanValue();
+    }
+
 }

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -78,9 +78,6 @@ import javax.swing.filechooser.FileFilter;
 
 import loci.formats.gui.ComboFileFilter;
 
-import omero.gateway.Gateway;
-import omero.gateway.SecurityContext;
-import omero.gateway.exception.DSOutOfServiceException;
 import org.apache.commons.collections4.CollectionUtils;
 import org.jdesktop.swingx.JXTaskPane;
 import org.openmicroscopy.shoola.agents.fsimporter.IconManager;
@@ -1847,25 +1844,10 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	}
 	private void enablesButtons(boolean enable) {
 		// imports only possible if server is not a read-only server
-		importButton.setEnabled(enable && canCreate());
-		mdeImportButton.setEnabled(enable && canCreate());
+		importButton.setEnabled(enable && ImporterAgent.canCreate());
+		mdeImportButton.setEnabled(enable && ImporterAgent.canCreate());
 
 		showMDEButton.setEnabled(enable);
-	}
-
-	/**
-	 * Helper function to use OMERO.importer with an server address of a read-only server (e.g. idr).
-	 * Check if users group is a non-read-only group.
-	 * @return
-	 */
-	private boolean canCreate() {
-		Gateway gw = ImporterAgent.getRegistry().getGateway();
-		SecurityContext ctx = new SecurityContext(gw.getLoggedInUser().getGroupId());
-		try {
-			return gw.canCreate(ctx);
-		} catch (DSOutOfServiceException e) {
-			return false;
-		}
 	}
 
 	@Override

--- a/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -564,7 +564,7 @@ public class DataServicesFactory
         if (!canCreate && LookupNames.MASTER_IMPORTER.equals(name)) {
             registry.getUserNotifier().notifyError("Read-only server",
                     "Cannot import on a read-only server!");
-            exitApplication(true, true);
+            //exitApplication(true, true);
         }
 
         try {

--- a/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -561,12 +561,6 @@ public class DataServicesFactory
         SecurityContext ctx = new SecurityContext(gid);
         boolean canCreate = omeroGateway.canCreate(ctx);
 
-        if (!canCreate && LookupNames.MASTER_IMPORTER.equals(name)) {
-            registry.getUserNotifier().notifyError("Read-only server",
-                    "Cannot import on a read-only server!");
-            //exitApplication(true, true);
-        }
-
         try {
             GroupData defaultGroup = null;
         	registry.bind(LookupNames.CAN_CREATE, canCreate);


### PR DESCRIPTION
enables use of OMERO.importer with read-only server for metadata annotations with OMERO.mde.
Could be useful to assist the user with IDR submissions or to export to other metadata and data formats using OMERO.mde.