### PR TITLE
Fix potential ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/env/ui/login/ServerEditor.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/login/ServerEditor.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.ui.login.ServerEditor
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2019 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -170,6 +170,7 @@ public class ServerEditor
 			@Override
 			public void valueChanged(ListSelectionEvent listSelectionEvent) {
 				fireEditProperty(true);
+				editButton.setEnabled(table.getSelectedIndex() >= 0);
 			}
 		});
 		removeButton = new JButton(icons.getIcon(IconManager.REMOVE));


### PR DESCRIPTION
Wee bugfix for https://github.com/ome/omero-insight/issues/256 .
Replicate issue: Click on the spanner to select server. Use CTRL click to deselect the current server. Click on the pencil to edit the hostname. Click ok. -> Crash
With this PR: If the server is deselected, the pencil icon will be deactivated.