### PR TITLE
Disable file format combobox

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/CustomizedFileChooser.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/CustomizedFileChooser.java
@@ -136,13 +136,13 @@ class CustomizedFileChooser
 					label.setText(FOLDER_LABEL);
 				setFileSelectionMode(DIRECTORIES_ONLY);
 				setCurrentDirectory(getFileSystemView().getHomeDirectory());
-				// Workaround to disable the (empty) file formats dropdown box:
-				List<Component> comps = UIUtilities.findComponents(this, JComboBox.class);
-				for (Component comp : comps) {
-					JComboBox box = (JComboBox)comp;
-					if (box.getItemCount() <= 1)
-						box.setEnabled(false);
-				}
+		}
+		// Workaround to disable useless file formats dropdown box:
+		List<Component> comps = UIUtilities.findComponents(this, JComboBox.class);
+		for (Component comp : comps) {
+			JComboBox box = (JComboBox)comp;
+			if (box.getItemCount() <= 1)
+				box.setEnabled(false);
 		}
 	}
 	

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/CustomizedFileChooser.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/CustomizedFileChooser.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.filechooser.CustomizedFileChooser 
  *
   *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -24,10 +24,12 @@ package org.openmicroscopy.shoola.util.ui.filechooser;
 
 
 //Java imports
+import java.awt.Component;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.io.File;
 import java.util.List;
+import javax.swing.JComboBox;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JTextField;
@@ -134,6 +136,13 @@ class CustomizedFileChooser
 					label.setText(FOLDER_LABEL);
 				setFileSelectionMode(DIRECTORIES_ONLY);
 				setCurrentDirectory(getFileSystemView().getHomeDirectory());
+				// Workaround to disable the (empty) file formats dropdown box:
+				List<Component> comps = UIUtilities.findComponents(this, JComboBox.class);
+				for (Component comp : comps) {
+					JComboBox box = (JComboBox)comp;
+					if (box.getItemCount() <= 0)
+						box.setEnabled(false);
+				}
 		}
 	}
 	

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/CustomizedFileChooser.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/CustomizedFileChooser.java
@@ -140,7 +140,7 @@ class CustomizedFileChooser
 				List<Component> comps = UIUtilities.findComponents(this, JComboBox.class);
 				for (Component comp : comps) {
 					JComboBox box = (JComboBox)comp;
-					if (box.getItemCount() <= 0)
+					if (box.getItemCount() <= 1)
 						box.setEnabled(false);
 				}
 		}


### PR DESCRIPTION
Workaround for https://github.com/ome/omero-insight/issues/271 . This "File Format" dropdown is part of Java's builtin JFileChooser, so I can't remove it. This PR is a proposed workaround which simply disables it in case it's empty.
![Screenshot 2022-01-14 at 13 53 39](https://user-images.githubusercontent.com/6575139/149527519-6c10d79d-de6a-416a-9746-afe29a953c1f.png)

Test: Make sure it's still enabled when it should be (e.g. attach a file), and that it is disabled when it is empty (e.g. download an image).

