### PR TITLE
Catch InvalidPathException

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/GenericFileChooser.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/GenericFileChooser.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2011 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2022 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -25,6 +25,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import javax.swing.JComboBox;
 import javax.swing.JFileChooser;
@@ -63,11 +64,16 @@ public class GenericFileChooser
 	 */
 	private void handleFileSelection(File f)
 	{
-		if (box == null || f == null) return;
-		if (Files.isSymbolicLink(Paths.get(f.getAbsolutePath())) || f.getName().endsWith(".lnk")) {
-			JOptionPane.showMessageDialog(null, "Cannot use shortcut " +
-					"from selection box.");
-			box.setSelectedItem(f.getParentFile());
+		if (box == null || f == null)
+			return;
+		try {
+			if (Files.isSymbolicLink(Paths.get(f.getAbsolutePath())) || f.getName().endsWith(".lnk")) {
+				JOptionPane.showMessageDialog(null, "Cannot use shortcut " +
+						"from selection box.");
+				box.setSelectedItem(f.getParentFile());
+			}
+		} catch (InvalidPathException e) {
+			// this is thrown on Windows 10 when "This PC" selected, just ignore.
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/ome/omero-insight/issues/111 .

To replicate the error: Open import dialog. In the drop down select "This PC". Insight crashes with InvalidPathException. Has to be tested on Windows 10.

Test: Check that Insight doesn't crash with this PR.
