### PR TITLE
Issue 210: javax.swing.JComponent: ArrayIndexOutOfBoundsException

### DIFF
--- a/src/config/container.xml
+++ b/src/config/container.xml
@@ -318,7 +318,7 @@
   <entry name="LookAndFeel">system</entry>
 
     <!-- Flag to use the CheckThreadViolationRepaintManager for debugging Swing thread issues -->
-    <entry name="DebugRepaintManager" type="boolean">true</entry>
+    <entry name="DebugRepaintManager" type="boolean">false</entry>
 
   <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    * Information related to the version of the software, name of the software,

--- a/src/config/container.xml
+++ b/src/config/container.xml
@@ -317,6 +317,9 @@
   -->
   <entry name="LookAndFeel">system</entry>
 
+    <!-- Flag to use the CheckThreadViolationRepaintManager for debugging Swing thread issues -->
+    <entry name="DebugRepaintManager" type="boolean">true</entry>
+
   <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    * Information related to the version of the software, name of the software,
    * etc.

--- a/src/config/containerImporter.xml
+++ b/src/config/containerImporter.xml
@@ -298,6 +298,9 @@
   -->
   <entry name="LookAndFeel">system</entry>
 
+    <!-- Flag to use the CheckThreadViolationRepaintManager for debugging Swing thread issues -->
+    <entry name="DebugRepaintManager" type="boolean">true</entry>
+
   <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    * Information related to the version of the software, name of the software,
    * etc.

--- a/src/config/containerImporter.xml
+++ b/src/config/containerImporter.xml
@@ -299,7 +299,7 @@
   <entry name="LookAndFeel">system</entry>
 
     <!-- Flag to use the CheckThreadViolationRepaintManager for debugging Swing thread issues -->
-    <entry name="DebugRepaintManager" type="boolean">true</entry>
+    <entry name="DebugRepaintManager" type="boolean">false</entry>
 
   <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    * Information related to the version of the software, name of the software,

--- a/src/main/java/org/openmicroscopy/shoola/Main.java
+++ b/src/main/java/org/openmicroscopy/shoola/Main.java
@@ -81,7 +81,7 @@ public class Main
 		if (posArgs.size() > 1) homeDir = posArgs.get(1);
 
 		try {
-			Path p = Path.of(Container.CONFIG_DIR, Container.CONFIG_FILE);
+			Path p = Path.get(Container.CONFIG_DIR, Container.CONFIG_FILE);
 			String content = Files.readString(p).replaceAll("\n", "");
 			Matcher m = Pattern.compile("DebugRepaintManager.+?>(.+?)<").matcher(content);
 			if (m.find() && Boolean.parseBoolean(m.group(1))) {

--- a/src/main/java/org/openmicroscopy/shoola/Main.java
+++ b/src/main/java/org/openmicroscopy/shoola/Main.java
@@ -29,6 +29,7 @@ package org.openmicroscopy.shoola;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.env.Container;
+//import org.openmicroscopy.shoola.util.CheckThreadViolationRepaintManager;
 
 import java.util.Arrays;
 import java.util.List;
@@ -72,6 +73,10 @@ public class Main
 		List<String> posArgs = Arrays.stream(args).filter(a -> !a.startsWith("--")).collect(Collectors.toList());
 		if (posArgs.size() > 0) configFile = posArgs.get(0);
 		if (posArgs.size() > 1) homeDir = posArgs.get(1);
+
+		// For debugging Swing thread exceptions:
+		//RepaintManager.setCurrentManager(new CheckThreadViolationRepaintManager());
+
 		Container.startup(homeDir, configFile, addArgs);
 	}
 	

--- a/src/main/java/org/openmicroscopy/shoola/Main.java
+++ b/src/main/java/org/openmicroscopy/shoola/Main.java
@@ -32,9 +32,10 @@ import org.openmicroscopy.shoola.env.Container;
 import org.openmicroscopy.shoola.util.CheckThreadViolationRepaintManager;
 
 import javax.swing.RepaintManager;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -81,9 +82,17 @@ public class Main
 		if (posArgs.size() > 1) homeDir = posArgs.get(1);
 
 		try {
-			Path p = Path.get(Container.CONFIG_DIR, Container.CONFIG_FILE);
-			String content = Files.readString(p).replaceAll("\n", "");
-			Matcher m = Pattern.compile("DebugRepaintManager.+?>(.+?)<").matcher(content);
+			String path = Container.CONFIG_DIR+ File.separator+Container.CONFIG_FILE;
+			StringBuilder configFileContent = new StringBuilder();
+			try (FileReader fr = new FileReader(path);
+				 BufferedReader br = new BufferedReader(fr)) {
+				 String line = br.readLine();
+				 while (line != null) {
+					 line = br.readLine();
+					 configFileContent.append(line);
+				 }
+			}
+			Matcher m = Pattern.compile("DebugRepaintManager.+?>(.+?)<").matcher(configFileContent.toString());
 			if (m.find() && Boolean.parseBoolean(m.group(1))) {
 					RepaintManager.setCurrentManager(new CheckThreadViolationRepaintManager());
 			}

--- a/src/main/java/org/openmicroscopy/shoola/Main.java
+++ b/src/main/java/org/openmicroscopy/shoola/Main.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.Main
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -29,10 +29,16 @@ package org.openmicroscopy.shoola;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.env.Container;
-//import org.openmicroscopy.shoola.util.CheckThreadViolationRepaintManager;
+import org.openmicroscopy.shoola.util.CheckThreadViolationRepaintManager;
 
+import javax.swing.RepaintManager;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /** 
@@ -74,8 +80,16 @@ public class Main
 		if (posArgs.size() > 0) configFile = posArgs.get(0);
 		if (posArgs.size() > 1) homeDir = posArgs.get(1);
 
-		// For debugging Swing thread exceptions:
-		//RepaintManager.setCurrentManager(new CheckThreadViolationRepaintManager());
+		try {
+			Path p = Path.of(Container.CONFIG_DIR, Container.CONFIG_FILE);
+			String content = Files.readString(p).replaceAll("\n", "");
+			Matcher m = Pattern.compile("DebugRepaintManager.+?>(.+?)<").matcher(content);
+			if (m.find() && Boolean.parseBoolean(m.group(1))) {
+					RepaintManager.setCurrentManager(new CheckThreadViolationRepaintManager());
+			}
+		} catch (IOException e) {
+			// Couldn't access config file, just ignore
+		}
 
 		Container.startup(homeDir, configFile, addArgs);
 	}

--- a/src/main/java/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserWellToolBar.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserWellToolBar.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -35,6 +35,7 @@ import javax.swing.JComboBox;
 import javax.swing.JPanel;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -240,8 +241,10 @@ class DataBrowserWellToolBar
 	 */
 	void setStatus(boolean busy)
 	{
-		busyLabel.setVisible(busy);
-		busyLabel.setBusy(busy);
+		SwingUtilities.invokeLater(() -> {
+			busyLabel.setVisible(busy);
+			busyLabel.setBusy(busy);
+		});
 	}
 	
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/agents/dataBrowser/view/QuickSearch.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/dataBrowser/view/QuickSearch.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.QuickSearch 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -46,6 +46,7 @@ import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
 import javax.swing.border.BevelBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -736,28 +737,30 @@ public class QuickSearch
 	 */
 	public void setFilteringStatus(boolean busy)
 	{
-		status.setBusy(busy);
-		cleanBar.removeAll();
-		if (busy) {
-			cleanBar.add(status);
-			cleanBar.setVisible(true);
-			setFocusOnArea();
-		} else {
-			cleanBar.add(clearButton);
-			boolean visible = false;
-			if (selectedNode != null) {
-				switch (selectedNode.getIndex()) {
-					case TAGS:
-					case COMMENTS:
-					case FULL_TEXT:
-						String text = searchArea.getText();
-						if (text != null && text.trim().length() == 0)
-							visible = true;
+		SwingUtilities.invokeLater(() -> {
+			status.setBusy(busy);
+			cleanBar.removeAll();
+			if (busy) {
+				cleanBar.add(status);
+				cleanBar.setVisible(true);
+				setFocusOnArea();
+			} else {
+				cleanBar.add(clearButton);
+				boolean visible = false;
+				if (selectedNode != null) {
+					switch (selectedNode.getIndex()) {
+						case TAGS:
+						case COMMENTS:
+						case FULL_TEXT:
+							String text = searchArea.getText();
+							if (text != null && text.trim().length() == 0)
+								visible = true;
+					}
 				}
+				cleanBar.setVisible(visible);
+				setFocusOnArea();
 			}
-			cleanBar.setVisible(visible);
-			setFocusOnArea();
-		}
+		});
 	}
 	
 	/** Removes the text from the display. */

--- a/src/main/java/org/openmicroscopy/shoola/agents/dataBrowser/view/SearchComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/dataBrowser/view/SearchComponent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -36,6 +36,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
+import javax.swing.SwingUtilities;
 
 
 import info.clearthought.layout.TableLayout;
@@ -496,10 +497,12 @@ public class SearchComponent
 	 */
 	public void setSearchEnabled(String text, boolean b)
 	{
-		searchButton.setEnabled(!b);
-		busyLabel.setEnabled(b);
-		busyLabel.setBusy(b);
-		progressLabel.setText(text);
+		SwingUtilities.invokeLater(() -> {
+			searchButton.setEnabled(!b);
+			busyLabel.setEnabled(b);
+			busyLabel.setBusy(b);
+			progressLabel.setText(text);
+		});
 	}
 	
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2021 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2022 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -60,6 +60,7 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -1404,9 +1405,11 @@ class LocationDialog extends JDialog implements ActionListener,
 
 		if (ImportDialog.REFRESH_LOCATION_PROPERTY.equals(name)
 				|| ImportDialog.PROPERTY_GROUP_CHANGED.equals(name)) {
-			busyLabel.setBusy(true);
-			busyLabel.setVisible(true);
-			addButton.setEnabled(false);
+			SwingUtilities.invokeLater(() -> {
+				busyLabel.setBusy(true);
+				busyLabel.setVisible(true);
+				addButton.setEnabled(false);
+			});
 			Object value = evt.getNewValue();
 			if(value != null && value instanceof ImportLocationDetails) {
 				ImportLocationDetails details = (ImportLocationDetails) evt
@@ -1706,9 +1709,11 @@ class LocationDialog extends JDialog implements ActionListener,
 		if (objects != null)
 			this.objects.addAll(objects);
 		this.container = container;
-		this.busyLabel.setBusy(false);
-		this.busyLabel.setVisible(false);
-		this.addButton.setEnabled(true);
+		SwingUtilities.invokeLater(() -> {
+					this.busyLabel.setBusy(false);
+					this.busyLabel.setVisible(false);
+					this.addButton.setEnabled(true);
+				});
 		populateUIWithDisplayData(findWithId(groups, currentGroupId), userID);
 		setInputsEnabled(true);
 	}

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -504,12 +504,14 @@ public class FileImportComponent
 		boolean b = status.isCancellable() || getFile().isDirectory();
 		if (!isCancelled() && !hasImportFailed() && b &&
 		        !status.isMarkedAsDuplicate()) {
-			busyLabel.setBusy(false);
-			busyLabel.setVisible(false);
-			status.markedAsCancel();
-			cancelButton.setEnabled(false);
-			cancelButton.setVisible(false);
-			firePropertyChange(CANCEL_IMPORT_PROPERTY, null, this);
+			SwingUtilities.invokeLater(() -> {
+				busyLabel.setBusy(false);
+				busyLabel.setVisible(false);
+				status.markedAsCancel();
+				cancelButton.setEnabled(false);
+				cancelButton.setVisible(false);
+				firePropertyChange(CANCEL_IMPORT_PROPERTY, null, this);
+			});
 		}
 	}
 
@@ -1459,8 +1461,10 @@ public class FileImportComponent
 	@Override
     public void onResultsSaving(String message, boolean busy)
 	{
-	    busyLabel.setVisible(busy);
-	    busyLabel.setBusy(busy);
+		SwingUtilities.invokeLater(() -> {
+			busyLabel.setVisible(busy);
+			busyLabel.setBusy(busy);
+		});
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -49,6 +49,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
 
 import omero.gateway.model.DataObject;
 import omero.gateway.model.DatasetData;
@@ -770,10 +771,12 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
      *            The component of reference of the rotation icon.
      */
     Icon startImport(JComponent component) {
-        uploadStarted = true;
-        setClosable(false);
-        busyLabel.setBusy(true);
-        repaint();
+        SwingUtilities.invokeLater(() -> {
+            uploadStarted = true;
+            setClosable(false);
+            busyLabel.setBusy(true);
+            repaint();
+        });
         return new RotationIcon(busyLabel.getIcon(), component, true);
     }
 
@@ -1073,8 +1076,10 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
 
     /** Invokes when the import is finished. */
     void onImportEnded() {
-        busyLabel.setBusy(false);
-        setClosable(true);
+        SwingUtilities.invokeLater(() -> {
+            busyLabel.setBusy(false);
+            setClosable(true);
+        });
     }
 
     /**

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2018 University of Dundee. All rights reserved.
+ *  Copyright (C) 2018-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -281,7 +281,9 @@ class ImporterUIElementLight extends ImporterUIElement {
     public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
         super.propertyChange(propertyChangeEvent);
         if (isScanning == null) {
-            scanningBusy.setBusy(true);
+            SwingUtilities.invokeLater(() -> {
+                scanningBusy.setBusy(true);
+            });
         }
     }
 }

--- a/src/main/java/org/openmicroscopy/shoola/agents/imviewer/view/ToolBar.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/imviewer/view/ToolBar.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -39,6 +39,7 @@ import javax.swing.JPanel;
 import javax.swing.JSeparator;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
 
 import org.jdesktop.swingx.JXBusyLabel;
 import org.openmicroscopy.shoola.agents.events.iviewer.ScriptDisplay;
@@ -442,8 +443,10 @@ class ToolBar
      */
     void setStatus(boolean busy)
     {
-    	busyLabel.setBusy(busy);
-    	busyLabel.setVisible(busy);
+		SwingUtilities.invokeLater(() -> {
+			busyLabel.setBusy(busy);
+			busyLabel.setVisible(busy);
+		});
     }
     
 	/**
@@ -454,19 +457,21 @@ class ToolBar
 	 * 			<code>false</code> to indicate that the creation is done.
 	 */
 	void setMeasurementLaunchingStatus(boolean b)
-	{ 
-		if (bar != null) {
-			measurementLabel.setBusy(b);
-    		if (!b) {
-    			bar.remove(measurementLabel);
-    			bar.add(measurementButton, MEASUREMENT_INDEX);
-        	} else {
-        		bar.remove(measurementButton);
-        		bar.add(measurementLabel, MEASUREMENT_INDEX);
-        	}
-    		bar.revalidate();
-    		bar.repaint();
-    	} 
+	{
+		SwingUtilities.invokeLater(() -> {
+			if (bar != null) {
+				measurementLabel.setBusy(b);
+				if (!b) {
+					bar.remove(measurementLabel);
+					bar.add(measurementButton, MEASUREMENT_INDEX);
+				} else {
+					bar.remove(measurementButton);
+					bar.add(measurementLabel, MEASUREMENT_INDEX);
+				}
+				bar.revalidate();
+				bar.repaint();
+			}
+		});
 	}
 
 	/** Sets the viewer in a separate window. */

--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/ToolBar.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -554,8 +554,10 @@ class ToolBar
      */
     void setStatus(boolean busy)
     {
-    	busyLabel.setBusy(busy);
-    	busyLabel.setVisible(busy);
+		SwingUtilities.invokeLater(() -> {
+			busyLabel.setBusy(busy);
+			busyLabel.setVisible(busy);
+		});
     }
     
     /** Updates the UI when a new object is selected. */

--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/util/AnalysisResultsItem.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/util/AnalysisResultsItem.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -374,20 +374,22 @@ public class AnalysisResultsItem
 	 */
 	public void notifyLoading(boolean load)
 	{
-		removeAll();
-		if (load) {
-			JXBusyLabel label = new JXBusyLabel(SIZE);
-			label.setBusy(true);
-			label.setEnabled(true);
-			add(label);
-			add(cancelButton);
-		} else {
-			//resultsButton.setEnabled(false);
-			add(resultsButton);
-			add(menuButton);
-		}
-		revalidate();
-		repaint();
+		SwingUtilities.invokeLater(() -> {
+			removeAll();
+			if (load) {
+				JXBusyLabel label = new JXBusyLabel(SIZE);
+				label.setBusy(true);
+				label.setEnabled(true);
+				add(label);
+				add(cancelButton);
+			} else {
+				//resultsButton.setEnabled(false);
+				add(resultsButton);
+				add(menuButton);
+			}
+			revalidate();
+			repaint();
+		});
 	}
 	
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -65,6 +65,7 @@ import javax.swing.JTextField;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.border.BevelBorder;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -1108,12 +1109,14 @@ class ToolBar
      */
     void setScriptsLoadingStatus(boolean loading)
     {
-        bar.remove(index);
-        busyLabel.setBusy(loading);
-        if (loading) bar.add(busyLabel, index);
-        else bar.add(scriptButton, index);
-        validate();
-        repaint();
+        SwingUtilities.invokeLater(() -> {
+            bar.remove(index);
+            busyLabel.setBusy(loading);
+            if (loading) bar.add(busyLabel, index);
+            else bar.add(scriptButton, index);
+            validate();
+            repaint();
+        });
     }
 
     /** Sets the permissions level.*/
@@ -1131,31 +1134,33 @@ class ToolBar
     /** Invokes when import is going on or finished.*/
     void onImport()
     {
-        //Clear first
-        importFailureLabel.setText("");
-        importFailureLabel.setVisible(false);
-        importSuccessLabel.setText("");
-        importSuccessLabel.setVisible(false);
-        importLabel.setBusy(model.isImporting());
-        importLabel.setVisible(model.isImporting());
-        int n = model.getImportFailureCount();
-        StringBuffer buffer;
-        if (n > 0) {
-            buffer = new StringBuffer();
-            buffer.append(n);
-            buffer.append(FAILED_TEXT);
-            importFailureLabel.setText(buffer.toString());
-            importFailureLabel.setVisible(true);
-        }
-        n = model.getImportSuccessCount();
-        if (n > 0) {
-            buffer = new StringBuffer();
-            buffer.append(n);
-            buffer.append(IMPORTED_TEXT);
-            importSuccessLabel.setText(buffer.toString());
-            importSuccessLabel.setVisible(true);
-        }
-        repaint();
+        SwingUtilities.invokeLater(() -> {
+            //Clear first
+            importFailureLabel.setText("");
+            importFailureLabel.setVisible(false);
+            importSuccessLabel.setText("");
+            importSuccessLabel.setVisible(false);
+            importLabel.setBusy(model.isImporting());
+            importLabel.setVisible(model.isImporting());
+            int n = model.getImportFailureCount();
+            StringBuffer buffer;
+            if (n > 0) {
+                buffer = new StringBuffer();
+                buffer.append(n);
+                buffer.append(FAILED_TEXT);
+                importFailureLabel.setText(buffer.toString());
+                importFailureLabel.setVisible(true);
+            }
+            n = model.getImportSuccessCount();
+            if (n > 0) {
+                buffer = new StringBuffer();
+                buffer.append(n);
+                buffer.append(IMPORTED_TEXT);
+                importSuccessLabel.setText(buffer.toString());
+                importSuccessLabel.setVisible(true);
+            }
+            repaint();
+        });
     }
 
     /** Clears the menus. */

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/ActivityComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/ActivityComponent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -49,6 +49,7 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
 
 import omero.model.OriginalFile;
 
@@ -356,16 +357,18 @@ public abstract class ActivityComponent
 	/** Resets the controls. */
 	private void reset()
 	{
-		toolBar.remove(buttonIndex);
-		toolBar.add(removeButton, buttonIndex);
-		removeButton.setEnabled(true);
-		exceptionButton.setVisible(false);
-		status.setBusy(false);
-		status.setVisible(false);
-		statusPane = iconLabel;
-		remove(statusPane);
-		add(statusPane, "0, 0, CENTER, CENTER");
-		repaint();
+		SwingUtilities.invokeLater(() -> {
+			toolBar.remove(buttonIndex);
+			toolBar.add(removeButton, buttonIndex);
+			removeButton.setEnabled(true);
+			exceptionButton.setVisible(false);
+			status.setBusy(false);
+			status.setVisible(false);
+			statusPane = iconLabel;
+			remove(statusPane);
+			add(statusPane, "0, 0, CENTER, CENTER");
+			repaint();
+		});
 	}
 	
 	/**
@@ -526,7 +529,9 @@ public abstract class ActivityComponent
 	/** Invokes when the activity starts. */ 
 	public void startActivity()
 	{
-		status.setBusy(true);
+		SwingUtilities.invokeLater(() -> {
+			status.setBusy(true);
+		});
 	}
 	
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/util/CheckThreadViolationRepaintManager.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/CheckThreadViolationRepaintManager.java
@@ -1,0 +1,179 @@
+package org.openmicroscopy.shoola.util;/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+import java.lang.ref.WeakReference;
+
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.RepaintManager;
+import javax.swing.SwingUtilities;
+
+/**
+ * <p>
+ * This class is used to detect Event Dispatch Thread rule violations<br>
+ * See <a
+ * href="http://java.sun.com/docs/books/tutorial/uiswing/misc/threads.html">How
+ * to Use Threads</a> for more info
+ * </p>
+ * <p/>
+ * <p>
+ * This is a modification of original idea of Scott Delap<br>
+ * Initial version of ThreadCheckingRepaintManager can be found here<br>
+ * <a href="http://www.clientjava.com/blog/2004/08/20/1093059428000.html">Easily
+ * Find Swing Threading Mistakes</a>
+ * </p>
+ *
+ * @author Scott Delap
+ * @author Alexander Potochkin
+ *
+ * https://swinghelper.dev.java.net/
+ */
+public class CheckThreadViolationRepaintManager extends RepaintManager {
+    // it is recommended to pass the complete check
+    private boolean completeCheck = true;
+
+    private WeakReference<JComponent> lastComponent;
+
+    public CheckThreadViolationRepaintManager(boolean completeCheck) {
+        this.completeCheck = completeCheck;
+    }
+
+    public CheckThreadViolationRepaintManager() {
+        this(true);
+    }
+
+    public boolean isCompleteCheck() {
+        return completeCheck;
+    }
+
+    public void setCompleteCheck(boolean completeCheck) {
+        this.completeCheck = completeCheck;
+    }
+
+    public synchronized void addInvalidComponent(JComponent component) {
+        checkThreadViolations(component);
+        super.addInvalidComponent(component);
+    }
+
+    public void addDirtyRegion(JComponent component, int x, int y, int w, int h) {
+        checkThreadViolations(component);
+        super.addDirtyRegion(component, x, y, w, h);
+    }
+
+    private void checkThreadViolations(JComponent c) {
+        if (!SwingUtilities.isEventDispatchThread() && (completeCheck || c.isShowing())) {
+            boolean repaint = false;
+            boolean fromSwing = false;
+            boolean imageUpdate = false;
+            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+            for (StackTraceElement st : stackTrace) {
+                if (repaint && st.getClassName().startsWith("javax.swing.")) {
+                    fromSwing = true;
+                }
+                if (repaint && "imageUpdate".equals(st.getMethodName())) {
+                    imageUpdate = true;
+                }
+                if ("repaint".equals(st.getMethodName())) {
+                    repaint = true;
+                    fromSwing = false;
+                }
+            }
+            if (imageUpdate) {
+                // assuming it is java.awt.image.ImageObserver.imageUpdate(...)
+                // image was asynchronously updated, that's ok
+                return;
+            }
+            if (repaint && !fromSwing) {
+                // no problems here, since repaint() is thread safe
+                return;
+            }
+            // ignore the last processed component
+            if (lastComponent != null && c == lastComponent.get()) {
+                return;
+            }
+            lastComponent = new WeakReference<JComponent>(c);
+            violationFound(c, stackTrace);
+        }
+    }
+
+    protected void violationFound(JComponent c, StackTraceElement[] stackTrace) {
+        System.out.println();
+        System.out.println("EDT violation detected");
+        System.out.println(c);
+        for (StackTraceElement st : stackTrace) {
+            System.out.println("\tat " + st);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        // set org.openmicroscopy.shoola.util.CheckThreadViolationRepaintManager
+        RepaintManager.setCurrentManager(new CheckThreadViolationRepaintManager());
+        // Valid code
+        SwingUtilities.invokeAndWait(new Runnable() {
+            public void run() {
+                test();
+            }
+        });
+        System.out.println("Valid code passed...");
+        repaintTest();
+        System.out.println("Repaint test - correct code");
+        // Invalide code (stack trace expected)
+        test();
+    }
+
+    static void test() {
+        JFrame frame = new JFrame("Am I on EDT?");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.add(new JButton("JButton"));
+        frame.pack();
+        frame.setVisible(true);
+        frame.dispose();
+    }
+
+    // this test must pass
+    static void imageUpdateTest() {
+        JFrame frame = new JFrame();
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        JEditorPane editor = new JEditorPane();
+        frame.setContentPane(editor);
+        editor.setContentType("text/html");
+        // it works with no valid image as well
+        editor.setText("<html><img src=\"file:\\lala.png\"></html>");
+        frame.setSize(300, 200);
+        frame.setVisible(true);
+    }
+
+    private static JButton test;
+
+    static void repaintTest() {
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    test = new JButton();
+                    test.setSize(100, 100);
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        // repaint(Rectangle) should be ok
+        test.repaint(test.getBounds());
+        test.repaint(0, 0, 100, 100);
+        test.repaint();
+    }
+}

--- a/src/main/java/org/openmicroscopy/shoola/util/CheckThreadViolationRepaintManager.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/CheckThreadViolationRepaintManager.java
@@ -1,4 +1,4 @@
-package org.openmicroscopy.shoola.util;/*
+/*
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -13,6 +13,8 @@ package org.openmicroscopy.shoola.util;/*
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
+package org.openmicroscopy.shoola.util;
 
 import java.lang.ref.WeakReference;
 

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/DummyPanel.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/DummyPanel.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2016-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -28,6 +28,7 @@ import java.awt.LayoutManager;
 
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 
 import org.jdesktop.swingx.JXBusyLabel;
 
@@ -140,8 +141,10 @@ public class DummyPanel extends JPanel {
      *            Flag to show the component as busy
      */
     public void setText(String text, boolean showBusy) {
-        this.label.setText(text);
-        busyLabel.setVisible(showBusy);
-        busyLabel.setBusy(showBusy);
+        SwingUtilities.invokeLater(() -> {
+            this.label.setText(text);
+            busyLabel.setVisible(showBusy);
+            busyLabel.setBusy(showBusy);
+        });
     }
 }

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/FileTableNode.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/FileTableNode.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.FileTableNode
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -31,6 +31,7 @@ import javax.swing.Box;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
+import javax.swing.SwingUtilities;
 
 //Third-party libraries
 import org.jdesktop.swingx.JXBusyLabel;
@@ -109,8 +110,10 @@ public class FileTableNode
 	 */
 	public void setStatus(boolean busy)
 	{
-		status.setBusy(busy);
-		if (!busy) status.setText("done");
+		SwingUtilities.invokeLater(() -> {
+			status.setBusy(busy);
+			if (!busy) status.setText("done");
+		});
 	}
 
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/MessengerDialog.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/MessengerDialog.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.MessengerDialog 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -51,6 +51,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
 import javax.swing.JTextPane;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.WindowConstants;
 import javax.swing.event.DocumentEvent;
@@ -329,8 +330,10 @@ public class MessengerDialog
 				MessengerDetails details = new MessengerDetails(email, comment);
 				details.setExtra(serverVersion);
 				details.setObjectToSubmit(files);
-				submitStatus.setVisible(true);
-				submitStatus.setBusy(true);
+				SwingUtilities.invokeLater(() -> {
+							submitStatus.setVisible(true);
+							submitStatus.setBusy(true);
+						});
 				details.setExceptionOnly(!submitFile.isSelected());
 				firePropertyChange(propertyName, null, details);
 			}
@@ -759,9 +762,11 @@ public class MessengerDialog
 	 */
 	public void setSubmitStatus(String text, boolean hide)
 	{
-		progressLabel.setText(text);
-		progress.setVisible(!hide);
-		progress.setBusy(!hide);
+		SwingUtilities.invokeLater(() -> {
+			progressLabel.setText(text);
+			progress.setVisible(!hide);
+			progress.setBusy(!hide);
+		});
 	}
 	
 	/**


### PR DESCRIPTION
Another attempt to fix https://github.com/ome/omero-insight/issues/210 .

Used the `CheckThreadViolationRepaintManager` mentioned in https://stackoverflow.com/questions/3153574/how-to-detect-swing-thread-policy-violations to detect more code in the import context which triggers UI updates outside the Swing thread. Moved these parts into `SwingUtilities.invokeLater()` calls. 

**Testing**: The exceptions of issue 210 are random and not reproducable. But what needs testing is that the import workflows still work.

/cc @jburel 