### PR TITLE
Move gateway calls to OMEROGateway

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/measurement/view/MeasurementViewerModel.java
@@ -1309,9 +1309,6 @@ class MeasurementViewerModel
     
     /**
      * Add ROIs to Folders
-     * 
-     * @param selectedObjects
-     *            The ROIs
      * @param folders
      *            The Folders
      * @param async
@@ -1337,16 +1334,7 @@ class MeasurementViewerModel
             try {
                 Registry reg = MetadataViewerAgent.getRegistry();
                 OmeroDataService ods = reg.getDataService();
-                Gateway gw = ods.getGateway();
-                DataManagerFacility dm = gw
-                        .getFacility(DataManagerFacility.class);
-                List<IObject> objs = new ArrayList<IObject>(folders.size());
-                for (FolderData f : folders)
-                    objs.add(f.asIObject());
-                objs = dm.saveAndReturnObject(getSecurityContext(), objs, null,
-                        null);
-                Collection<FolderData> result = PojoMapper
-                        .asCastedDataObjects(objs);
+                Collection<FolderData> result = ods.saveROIFolders(getSecurityContext(), folders);
                 Collection<Long> ids = Pojos.extractIds(this.folders);
                 for (FolderData f : result) {
                     if (!ids.contains(f.getId()))

--- a/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -144,9 +144,6 @@ public class DataServicesFactory
 	/** The Administration service adapter. */
 	private AdminService				admin;
 
-    /** Flag indicating that we try to re-establish the connection.*/
-    private final AtomicBoolean reconnecting = new AtomicBoolean(false);
-
 	/**
 	 * Attempts to create a new instance.
      * 
@@ -262,7 +259,6 @@ public class DataServicesFactory
                 String name = evt.getPropertyName();
                 if (NotificationDialog.CLOSE_NOTIFICATION_PROPERTY.equals(name))
                 {
-                    reconnecting.set(false);
                     connectionDialog = null;
                     exitApplication(true, true);
                 } else if (
@@ -270,7 +266,6 @@ public class DataServicesFactory
                             name))
                 {
                     connectionDialog = null;
-                    reconnecting.set(false);
                     int index = (Integer) evt.getNewValue();
                     if (index == ConnectionExceptionHandler.LOST_CONNECTION)
                         reconnect();
@@ -335,7 +330,6 @@ public class DataServicesFactory
             connectionDialog.setVisible(false);
             connectionDialog.dispose();
             connectionDialog = null;
-            reconnecting.set(false);
         } else {
             //connectionDialog.setVisible(false);
             message = "A failure occurred while attempting to " +
@@ -368,8 +362,8 @@ public class DataServicesFactory
 	 */
 	public void sessionExpiredExit(int index, Throwable exc)
 	{
-	    if (reconnecting.get()) return;
-		reconnecting.set(true);
+        if (connectionDialog != null && connectionDialog.isVisible())
+            return;
 		String message;
 		if (exc != null) {
 			LogMessage msg = new LogMessage();

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -42,6 +42,8 @@ import java.util.Set;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
 
+import omero.gateway.facility.RawDataFacility;
+import omero.gateway.model.PixelsData;
 import org.apache.commons.collections4.CollectionUtils;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 
@@ -256,7 +258,7 @@ import omero.gateway.model.WellSampleData;
  * @since OME2.2
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-class OMEROGateway
+public class OMEROGateway
 {
 
 	/** Identifies the fileset as root. */
@@ -7581,4 +7583,34 @@ class OMEROGateway
         return value.booleanValue();
     }
 
+	public Collection<String> getLookupTables(SecurityContext ctx) throws DSOutOfServiceException, DSAccessException {
+		try {
+			return gw.getFacility(BrowseFacility.class).getLookupTables(ctx);
+		} catch (Exception e) {
+			handleException(e, "Cannot retrieve lookup tables.");
+		}
+		return null;
+	}
+
+	public Map<Integer, int[]> getHistogram(SecurityContext ctx,
+											PixelsData pixels,
+											int[] channels, int z, int t)
+			throws DSOutOfServiceException, DSAccessException {
+		try {
+			RawDataFacility f = gw.getFacility(RawDataFacility.class);
+			return f.getHistogram(ctx, pixels, channels, z, t);
+		} catch (Exception e) {
+			handleException(e, "Cannot retrieve lookup tables.");
+		}
+		return null;
+	}
+
+	public int getROICount(SecurityContext ctx, long imageId) throws DSOutOfServiceException, DSAccessException {
+		try {
+			return gw.getFacility(ROIFacility.class).getROICount(ctx, imageId);
+		} catch (Exception e) {
+			handleException(e, "Cannot retrieve ROI count.");
+		}
+		return -1;
+	}
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -43,6 +43,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
 
 import omero.gateway.facility.RawDataFacility;
+import omero.gateway.model.FolderData;
 import omero.gateway.model.PixelsData;
 import org.apache.commons.collections4.CollectionUtils;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
@@ -258,7 +259,7 @@ import omero.gateway.model.WellSampleData;
  * @since OME2.2
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class OMEROGateway
+class OMEROGateway
 {
 
 	/** Identifies the fileset as root. */
@@ -1396,7 +1397,6 @@ public class OMEROGateway
 	 * @return The {@link ExperimenterData} of the current user.
 	 * @throws DSOutOfServiceException If the connection is broken, or
 	 * logged in.
-	 * @see IPojosPrx#getUserDetails(Set, Map)
 	 */
 	ExperimenterData getUserDetails(SecurityContext ctx, String name,
 			boolean connectionError)
@@ -1441,7 +1441,7 @@ public class OMEROGateway
 	
     /**
      * Get the omero client properties from the server
-     * @param The groupId for the {@link SecurityContext}
+     * @param groupId The groupId for the {@link SecurityContext}
      * @return See above.
      * @throws DSAccessException
      * @throws DSOutOfServiceException
@@ -1460,7 +1460,7 @@ public class OMEROGateway
 
 	/**
 	 * Get the server properties from the server
-	 * @param The groupId for the {@link SecurityContext}
+	 * @param groupId The groupId for the {@link SecurityContext}
 	 * @return See above.
 	 * @throws DSAccessException
 	 * @throws DSOutOfServiceException
@@ -1640,7 +1640,6 @@ public class OMEROGateway
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#loadContainerHierarchy(Class, List, Map)
 	 */
 	Collection<DataObject> loadContainerHierarchy(SecurityContext ctx, Class rootType,
 			List rootIDs, Parameters options)
@@ -1662,9 +1661,8 @@ public class OMEROGateway
 	 * contain the specified Images.
 	 * The annotation for the current user is also linked to the object.
 	 * Annotations are currently possible only for Image and Dataset.
-	 * Wraps the call to the
-	 * {@link IPojos#findContainerHierarchies(Class, List, Map)}
-	 * and maps the result calling {@link PojoMapper#convertToDataObjects(Set)}.
+	 * Wraps the call to the findContainerHierarchies(Class, List, Map)
+	 * and maps the result calling convertToDataObjects(Set).
 	 *
 	 * @param ctx The security context, necessary to determine the service.
 	 * @param rootNodeType  top-most type which will be searched for
@@ -1677,7 +1675,6 @@ public class OMEROGateway
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#findContainerHierarchies(Class, List, Map)
 	 */
 	Collection<DataObject> findContainerHierarchy(SecurityContext ctx, Class rootNodeType,
 			List leavesIDs, Parameters options)
@@ -1720,7 +1717,6 @@ public class OMEROGateway
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#findAnnotations(Class, List, List, Map)
 	 */
 	Map loadAnnotations(SecurityContext ctx, Class nodeType, List nodeIDs,
 			List<Class> annotationTypes, List annotatorIDs, Parameters options)
@@ -1810,8 +1806,8 @@ public class OMEROGateway
 	/**
 	 * Retrieves the images contained in containers specified by the
 	 * node type.
-	 * Wraps the call to the {@link IPojos#getImages(Class, List, Parameters)}
-	 * and maps the result calling {@link PojoMapper#convertToDataObjects(Set)}.
+	 * Wraps the call to the getImages(Class, List, Parameters)
+	 * and maps the result calling convertToDataObjects(Set).
 	 *
 	 * @param ctx The security context.
 	 * @param nodeType  The type of container. Can be either Project, Dataset.
@@ -1821,7 +1817,6 @@ public class OMEROGateway
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#getImages(Class, List, Map)
 	 */
 	Collection<ImageData> getContainerImages(SecurityContext ctx, Class nodeType, List nodeIDs,
 			Parameters options)
@@ -1851,7 +1846,6 @@ public class OMEROGateway
      * @throws DSAccessException
      *             If an error occurred while trying to retrieve data from OMERO
      *             service.
-     * @see IPojos#getUserImages(Map)
      */
     Collection<ImageData> getUserImages(SecurityContext ctx, long userID, boolean orphan)
             throws DSOutOfServiceException, DSAccessException {
@@ -1878,12 +1872,10 @@ public class OMEROGateway
 	 * @param property		One of the properties defined by this class.
 	 * @param ids           The identifiers of the objects.
 	 * @param options		Options to retrieve the data.
-	 * @param rootNodeIDs	Set of root node IDs.
 	 * @return See above.
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#getCollectionCount(String, String, List, Map)
 	 */
 	Map getCollectionCount(SecurityContext ctx, Class rootNodeType,
 			String property, List ids, Parameters options)
@@ -1910,12 +1902,10 @@ public class OMEROGateway
 	 *
 	 * @param ctx The security context.
 	 * @param object The object to create.
-	 * @param options Options to create the data.
 	 * @return See above.
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#createDataObject(IObject, Map)
 	 */
 	IObject createObject(SecurityContext ctx, IObject object)
 		throws DSOutOfServiceException, DSAccessException
@@ -1928,13 +1918,11 @@ public class OMEROGateway
 	 *
 	 * @param ctx The security context.
 	 * @param object The object to create.
-	 * @param options Options to create the data.
 	 * @param userName The name of the user to create data for.
 	 * @return See above.
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#createDataObject(IObject, Map)
 	 */
 	IObject createObject(SecurityContext ctx, IObject object, String userName)
 		throws DSOutOfServiceException, DSAccessException
@@ -1952,12 +1940,10 @@ public class OMEROGateway
 	 *
 	 * @param ctx The security context.
 	 * @param objects The objects to create.
-	 * @param options Options to create the data.
 	 * @return See above.
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#createDataObjects(IObject[], Map)
 	 */
 	List<IObject> createObjects(SecurityContext ctx, List<IObject> objects)
 		throws DSOutOfServiceException, DSAccessException
@@ -1970,13 +1956,11 @@ public class OMEROGateway
 	 *
 	 * @param ctx The security context.
 	 * @param objects The objects to create.
-	 * @param options Options to create the data.
 	 * @param userName The name of the user.s
 	 * @return See above.
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#createDataObjects(IObject[], Map)
 	 */
 	List<IObject> createObjects(SecurityContext ctx, List<IObject> objects,
 			String userName)
@@ -2042,7 +2026,6 @@ public class OMEROGateway
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#updateDataObject(IObject, Map)
 	 */
 	IObject saveAndReturnObject(SecurityContext ctx, IObject object,
 			Map options)
@@ -2069,7 +2052,6 @@ public class OMEROGateway
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#updateDataObject(IObject, Map)
 	 */
 	IObject saveAndReturnObject(SecurityContext ctx, IObject object,
 			Map options, String userName)
@@ -2096,7 +2078,6 @@ public class OMEROGateway
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#updateDataObject(IObject, Map)
 	 */
 	List<IObject> saveAndReturnObject(SecurityContext ctx,
 			List<IObject> objects, Map options, String userName)
@@ -2121,7 +2102,6 @@ public class OMEROGateway
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#updateDataObject(IObject, Map)
 	 */
 	IObject updateObject(SecurityContext ctx, IObject object,
 			Parameters options)
@@ -2148,7 +2128,6 @@ public class OMEROGateway
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
-	 * @see IPojos#updateDataObjects(IObject[], Map)
 	 */
 	List<IObject> updateObjects(SecurityContext ctx, List<IObject> objects,
 			Parameters options)
@@ -2922,7 +2901,7 @@ public class OMEROGateway
 	 * Retrieves an updated version of the specified object.
 	 *
 	 * @param ctx The security context.
-	 * @param dataObjectThe object to retrieve.
+	 * @param dataObject The object to retrieve.
 	 * @param name The name of the object.
 	 * @param
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
@@ -3024,7 +3003,7 @@ public class OMEROGateway
 	 * Retrieves the groups visible by the current experimenter.
 	 *
 	 * @param ctx The security context.
-	 * @param loggedInUser The user currently logged in.
+	 * @param user The user currently logged in.
 	 * @return See above.
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
@@ -3807,7 +3786,7 @@ public class OMEROGateway
 	 * including nested sub-directories.
 	 *
 	 * @param ctx The security context.
-	 * @param Either a group or a user.
+	 * @param type Either a group or a user.
 	 * @param id The identifier of the user or group or <code>-1</code>
 	 * 			 if not specified.
 	 * @return See above.
@@ -3834,7 +3813,7 @@ public class OMEROGateway
 	 * including nested sub-directories.
 	 *
 	 * @param ctx The security context.
-	 * @param Either a group or a user.
+	 * @param type Either a group or a user.
 	 * @param id The identifier of the user or group or <code>-1</code>
 	 * 			 if not specified.
 	 * @return See above.
@@ -4133,8 +4112,6 @@ public class OMEROGateway
 	 * @param ctx The security context.
 	 * @param pixelsID	The pixels ID.
 	 * @param userID	The id of the user.
-	 * @param convert   Pass <code>true</code> to convert the object,
-	 * 					<code>false</code> otherwise.
 	 * @return Map whose key is the experimenter who set the settings,
 	 * 		  and the value is the rendering settings itself.
 	 * @throws DSOutOfServiceException  If the connection is broken, or logged
@@ -4837,7 +4814,6 @@ public class OMEROGateway
 	 * @param stepping  The stepping used to project. Default is <code>1</code>.
 	 * @param algorithm The projection's algorithm.
 	 * @param channels  The channels to project.
-	 * @param datasets  The collection of datasets to add the image to.
 	 * @param name      The name of the projected image.
 	 * @param pixType   The destination Pixels type. If <code>null</code>, the
      * 					source Pixels set pixels type will be used.
@@ -5357,10 +5333,7 @@ public class OMEROGateway
 	 * Creates a movie. Returns the id of the annotation hosting the movie.
 	 *
 	 * @param ctx The security context.
-	 * @param imageID 	The id of the image.
-	 * @param pixelsID	The id of the pixels.
-	 * @param userID	The id of the user.
-     * @param channels 	The channels to map.
+	 * @param userID 	The id of the user.
      * @param param 	The parameters to create the movie.
 	 * @return See above.
 	 * @throws DSOutOfServiceException  If the connection is broken, or logged
@@ -5468,7 +5441,6 @@ public class OMEROGateway
 	 * Returns all the scripts that the user can run.
 	 *
 	 * @param ctx The security context.
-	 * @param experimenter The experimenter or <code>null</code>.
 	 * @return See above.
 	 * @throws DSOutOfServiceException  If the connection is broken, or logged
 	 *                                  in.
@@ -5902,10 +5874,6 @@ public class OMEROGateway
 	 * @param ctx The security context.
 	 * @param object Host information about the file to import.
 	 * @param file The file to import.
-	 * @param archived Pass <code>true</code> to archived the files,
-	 *                 <code>false</code> otherwise.
-	 * @param depth The depth used to set the name. This will be taken into
-	 *              account if the file is a directory.
 	 * @return See above.
 	 * @throws ImportException If an error occurred while importing.
 	 */
@@ -6186,10 +6154,9 @@ public class OMEROGateway
 	 * Returns the file
 	 *
 	 * @param index Either OME-XML or OME-TIFF.
-	 * @param file		The file to write the bytes.
 	 * @param imageID	The id of the image.
 	 * @param ctx The security context.
-	 * @param file The file to write the bytes.
+	 * @param f The file to write the bytes.
 	 * @param imageID The id of the image.
 	 * @return See above.
 	 * @throws DSOutOfServiceException  If the connection is broken, or logged
@@ -6528,7 +6495,7 @@ public class OMEROGateway
 	 * number of experimenters in the group.
 	 *
 	 * @param ctx The security context.
-	 * @param ids The group identifiers.
+	 * @param groupIds The group identifiers.
 	 * @return See above
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
@@ -6697,7 +6664,7 @@ public class OMEROGateway
 	 * experimenters if the value passed is <code>-1</code>.
 	 *
 	 * @param ctx The security context.
-	 * @param id The group identifier or <code>-1</code>.
+	 * @param groupID The group identifier or <code>-1</code>.
 	 * @return See above.
 	 * @throws DSOutOfServiceException  If the connection is broken, or logged
 	 *                                  in.
@@ -7044,8 +7011,7 @@ public class OMEROGateway
 	 * Uploads the photo hosting the user photo.
 	 *
 	 * @param ctx The security context.
-	 * @param fileID The id of the file.
-	 * @param size   The size of the file.
+	 * @param file The file.
 	 * @return See above
 	 * @throws DSOutOfServiceException  If the connection is broken, or logged
 	 *                                  in.
@@ -7261,7 +7227,6 @@ public class OMEROGateway
 	 * Retrieves the dimensions in microns of the specified pixels set.
 	 *
 	 * @param ctx The security context.
-	 * @param pixelsID  The pixels set ID.
 	 * @return See above.
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
 	 * @throws DSAccessException If an error occurred while trying to
@@ -7409,7 +7374,7 @@ public class OMEROGateway
 	 * @param rootIDs The collection of object's ids the annotations are linked
 	 * to.
 	 * @param nsInclude The annotation's name space to include if any.
-	 * @param nsExlcude The annotation's name space to exclude if any.
+	 * @param nsExclude The annotation's name space to exclude if any.
 	 * @param options Options to retrieve the data.
 	 * @return See above.
 	 * @throws DSOutOfServiceException If the connection is broken, or not logged in
@@ -7612,5 +7577,23 @@ public class OMEROGateway
 			handleException(e, "Cannot retrieve ROI count.");
 		}
 		return -1;
+	}
+
+	public Collection<FolderData> saveROIFolders(SecurityContext ctx, Collection<FolderData> folders)
+			throws DSOutOfServiceException, DSAccessException {
+		try {
+			DataManagerFacility dm = this.gw.getFacility(DataManagerFacility.class);
+			List<IObject> objs = new ArrayList<IObject>(folders.size());
+			for (FolderData f : folders)
+				objs.add(f.asIObject());
+			objs = dm.saveAndReturnObject(ctx, objs, null,
+					null);
+			Collection<FolderData> result = PojoMapper
+					.asCastedDataObjects(objs);
+			return result;
+		} catch (Exception e) {
+			handleException(e, "Cannot save ROI folders");
+		}
+		return Collections.EMPTY_LIST;
 	}
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataService.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataService.java
@@ -61,12 +61,6 @@ public interface OmeroDataService
 	public static final String IMAGES_PROPERTY = "images";
 
 	/**
-	 * Get a reference to the {@link OMEROGateway}
-	 * @return See above
-	 */
-	public OMEROGateway getOMEROGateway();
-
-	/**
 	 * Retrieves hierarchy trees rooted by a given node.
 	 * i.e. the requested node as root and all of its descendants.
 	 *

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataService.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataService.java
@@ -63,7 +63,13 @@ public interface OmeroDataService
 	 * @return See above
 	 */
 	public Gateway getGateway();
-	
+
+	/**
+	 * Get a reference to the {@link OMEROGateway}
+	 * @return See above
+	 */
+	public OMEROGateway getOMEROGateway();
+
 	/**
 	 * Retrieves hierarchy trees rooted by a given node.
 	 * i.e. the requested node as root and all of its descendants.

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataService.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataService.java
@@ -26,9 +26,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import omero.api.StatefulServiceInterfacePrx;
 
+import omero.gateway.model.FolderData;
 import org.openmicroscopy.shoola.env.data.model.DeletableObject;
 
 import omero.gateway.Gateway;
@@ -57,12 +59,6 @@ public interface OmeroDataService
 	 * Identifies the count property.
 	 */
 	public static final String IMAGES_PROPERTY = "images";
-
-	/**
-	 * Get a reference to the {@link Gateway}
-	 * @return See above
-	 */
-	public Gateway getGateway();
 
 	/**
 	 * Get a reference to the {@link OMEROGateway}
@@ -512,5 +508,11 @@ public interface OmeroDataService
 	 * @throws DSAccessException If an error occurred while trying to
 	 * retrieve data from OMERO service.
 	*/
-	public Map<Long, List<DatasetData>> findDatasetsByImageId(SecurityContext ctx, List<Long> imgIds) throws DSOutOfServiceException, DSAccessException;
+	public Map<Long, List<DatasetData>> findDatasetsByImageId(SecurityContext ctx, List<Long> imgIds)
+			throws DSOutOfServiceException, DSAccessException;
+
+	public Collection<FolderData> saveROIFolders(SecurityContext ctx, Collection<FolderData> folders)
+			throws ExecutionException, DSOutOfServiceException, DSAccessException;
+
+	public int getROICount(SecurityContext ctx, long imageId) throws DSOutOfServiceException, DSAccessException;
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -31,9 +31,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import omero.cmd.Request;
 import omero.cmd.graphs.ChildOption;
+import omero.gateway.facility.DataManagerFacility;
+import omero.gateway.model.FolderData;
 import omero.model.Annotation;
 import omero.model.AnnotationAnnotationLink;
 import omero.model.Dataset;
@@ -114,11 +117,6 @@ class OmeroDataServiceImpl
 
 	/** Reference to the entry point to access the <i>OMERO</i> services. */
 	private OMEROGateway gateway;
-
-	@Override
-	public Gateway getGateway() {
-	    return gateway.getGateway();
-	}
 
 	@Override
 	public OMEROGateway getOMEROGateway() {
@@ -499,7 +497,6 @@ class OmeroDataServiceImpl
 
 	/**
 	 * Implemented as specified by {@link OmeroDataService}.
-	 * @see OmeroDataService#getArchivedFiles(SecurityContext, File, long, boolean)
 	 */
 	public Map<Boolean, Object> getArchivedImage(SecurityContext ctx,
 			File file, long imageID, boolean keepOriginalPath)
@@ -513,7 +510,6 @@ class OmeroDataServiceImpl
 
 	/**
 	 * Implemented as specified by {@link OmeroDataService}.
-	 * @see OmeroDataService#updateExperimenter(SecurityContext, ExperimenterData, GroupData)
 	 */
 	public ExperimenterData updateExperimenter(SecurityContext ctx,
 			ExperimenterData exp, GroupData group)
@@ -594,7 +590,6 @@ class OmeroDataServiceImpl
 
 	/**
 	 * Implemented as specified by {@link OmeroDataService}.
-	 * @see OmeroDataService#advancedSearchFor(List, SearchDataContext)
 	 */
 	public SearchResultCollection search(SecurityContext ctx,
 	        SearchParameters context)
@@ -735,7 +730,7 @@ class OmeroDataServiceImpl
     	
         /**
          * Tries to convert all search terms into ids;
-         * @param terms
+         * @param query terms
          * @return The ids or null if one or multiple terms contain non numeric characters
          */
         private long[] convertSearchTermsToIds(String query) {
@@ -1153,7 +1148,6 @@ class OmeroDataServiceImpl
 	
 	/**
 	 * Implemented as specified by {@link OmeroDataService}.
-	 * @see OmeroDataService#findDatasetsByImageId(SecurityContext ctx, imgId)
 	 */
 	public Map<Long, List<DatasetData>> findDatasetsByImageId(SecurityContext ctx, List<Long> imgIds) throws DSOutOfServiceException, DSAccessException
 		{
@@ -1178,4 +1172,12 @@ class OmeroDataServiceImpl
 		return result;
 	}
 
+	public Collection<FolderData> saveROIFolders(SecurityContext ctx, Collection<FolderData> folders)
+			throws DSOutOfServiceException, DSAccessException {
+		return gateway.saveROIFolders(ctx, folders);
+	}
+
+	public int getROICount(SecurityContext ctx, long imageId) throws DSOutOfServiceException, DSAccessException {
+		return gateway.getROICount(ctx, imageId);
+	}
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -118,11 +118,6 @@ class OmeroDataServiceImpl
 	/** Reference to the entry point to access the <i>OMERO</i> services. */
 	private OMEROGateway gateway;
 
-	@Override
-	public OMEROGateway getOMEROGateway() {
-		return gateway;
-	}
-
 	/**
 	 * Unlinks the collection of children from the specified parent.
 	 *

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -119,7 +119,12 @@ class OmeroDataServiceImpl
 	public Gateway getGateway() {
 	    return gateway.getGateway();
 	}
-	
+
+	@Override
+	public OMEROGateway getOMEROGateway() {
+		return gateway;
+	}
+
 	/**
 	 * Unlinks the collection of children from the specified parent.
 	 *

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageService.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageService.java
@@ -862,4 +862,9 @@ public interface OmeroImageService
      */
 	RawPixelsStorePrx createPixelsStore(SecurityContext ctx)
             throws DSAccessException, DSOutOfServiceException;
+
+	public Map<Integer, int[]> getHistogram(SecurityContext ctx,
+											PixelsData pixels,
+											int[] channels, int z, int t) throws DSAccessException,
+			DSOutOfServiceException;
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -570,8 +570,7 @@ class OmeroImageServiceImpl
             return OmeroImageServiceImpl.LOOKUP_TABLES;
 
         try {
-            OmeroImageServiceImpl.LOOKUP_TABLES = gateway.getGateway()
-                    .getFacility(BrowseFacility.class).getLookupTables(ctx);
+            OmeroImageServiceImpl.LOOKUP_TABLES = gateway.getLookupTables(ctx);
             return OmeroImageServiceImpl.LOOKUP_TABLES;
         } catch (Exception e) {
             context.getLogger().warn(this, e.getMessage());

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -214,10 +214,8 @@ class OmeroImageServiceImpl
 	 * Imports the specified candidates.
 	 *
 	 * @param ctx The security context.
-	 * @param candidates The file to import.
 	 * @param status The original status.
 	 * @param object The object hosting information about the import.
-	 * @param ioList The containers where to import the files.
 	 * @param list   The list of annotations.
 	 * @param userID The identifier of the user.
 	 * @param hcs Value returns by the import containers.
@@ -327,9 +325,9 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Creates a <code>BufferedImage</code> from the passed array of bytes.
+	 * Creates a <code>BufferedImage</code> from the passed path.
 	 *
-	 * @param values    The array of bytes.
+	 * @param path    The path,
 	 * @return See above.
 	 * @throws RenderingServiceException If we cannot create an image.
 	 */
@@ -643,7 +641,6 @@ class OmeroImageServiceImpl
 
 	/**
 	 * Implemented as specified by {@link OmeroImageService}.
-	 * @see OmeroImageService#getThumbnailSet(SecurityContext, List, int)
 	 */
 	public Map<Long, BufferedImage> getThumbnailSet(SecurityContext ctx,
 		Collection<Long> pixelsID, int max)
@@ -838,7 +835,6 @@ class OmeroImageServiceImpl
 
 	/**
 	 * Implemented as specified by {@link OmeroImageService}.
-	 * @see OmeroImageService#resetRenderingSettings(Class, List)
 	 */
 	public Map resetRenderingSettings(SecurityContext ctx, Class rootNodeType,
 		List nodesID)
@@ -878,7 +874,6 @@ class OmeroImageServiceImpl
 
 	/**
 	 * Implemented as specified by {@link OmeroImageService}.
-	 * @see OmeroImageService#getRenderingSettings(ctx, long, long)
 	 */
 	public Map<DataObject, Collection<RndProxyDef>> getRenderingSettings(
 	        SecurityContext ctx, long pixelsID, long userID)
@@ -889,7 +884,6 @@ class OmeroImageServiceImpl
 
 	/**
 	 * Implemented as specified by {@link OmeroImageService}.
-	 * @see OmeroImageService#getRenderingSettingsFor(long, long)
 	 */
 	public List<RndProxyDef> getRenderingSettingsFor(SecurityContext ctx,
 		long pixelsID, long userID)
@@ -1025,8 +1019,6 @@ class OmeroImageServiceImpl
 
 	/**
 	 * Implemented as specified by {@link OmeroImageService}.
-	 * @see OmeroImageService#importFile(ImportableObject,
-	 * ImportableFile, long, long, boolean)
 	 */
 	public Object importFile(ImportableObject object,
 							 ImportableFile importable, boolean close)
@@ -1594,8 +1586,6 @@ class OmeroImageServiceImpl
 
 	/**
 	 * Implemented as specified by {@link OmeroImageService}.
-	 * @see OmeroImageService#exportImageAsOMEObject(SecurityContext, int, long,
-	 * File, Target)
 	 */
 	public Object exportImageAsOMEFormat(SecurityContext ctx, int index,
 			long imageID, File file, Target target)
@@ -1796,7 +1786,6 @@ class OmeroImageServiceImpl
 
 	/**
 	 * Implemented as specified by {@link OmeroDataService}.
-	 * @see OmeroImageService#loadRatings(SecurityContext, Class, long, long)
 	 */
 	public Collection loadROIMeasurements(SecurityContext ctx, Class type,
 		long id, long userID)
@@ -2021,7 +2010,6 @@ class OmeroImageServiceImpl
 
 	/**
 	 * Implemented as specified by {@link OmeroDataService}.
-	 * @see OmeroImageService#getRenderingDef(SecurityContext, long)
 	 */
 	public RndProxyDef getSettings(SecurityContext ctx, long rndID)
         throws DSOutOfServiceException, DSAccessException
@@ -2044,4 +2032,10 @@ class OmeroImageServiceImpl
         return null;
     }
 
+	public Map<Integer, int[]> getHistogram(SecurityContext ctx,
+											PixelsData pixels,
+											int[] channels, int z, int t) throws DSOutOfServiceException,
+			DSAccessException {
+		return gateway.getHistogram(ctx, pixels, channels, z, t);
+	}
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/HistogramLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/HistogramLoader.java
@@ -23,7 +23,6 @@ package org.openmicroscopy.shoola.env.data.views.calls;
 import java.util.Map;
 
 import omero.gateway.SecurityContext;
-import omero.gateway.facility.RawDataFacility;
 import omero.gateway.model.ImageData;
 
 import org.openmicroscopy.shoola.env.data.views.BatchCall;
@@ -61,7 +60,7 @@ public class HistogramLoader extends BatchCallTree {
             final int z, final int t) {
         loadCall = new BatchCall("Loading Histogram data") {
             public void doCall() throws Exception {
-                result = context.getDataService().getOMEROGateway().getHistogram(ctx, img.getDefaultPixels(),
+                result = context.getImageService().getHistogram(ctx, img.getDefaultPixels(),
                         channels, z, t);
             }
         };

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/HistogramLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/HistogramLoader.java
@@ -61,11 +61,8 @@ public class HistogramLoader extends BatchCallTree {
             final int z, final int t) {
         loadCall = new BatchCall("Loading Histogram data") {
             public void doCall() throws Exception {
-                try (RawDataFacility f = context.getGateway().getFacility(
-                        RawDataFacility.class)) {
-                    result = f.getHistogram(ctx, img.getDefaultPixels(),
-                            channels, z, t);
-                }
+                result = context.getDataService().getOMEROGateway().getHistogram(ctx, img.getDefaultPixels(),
+                        channels, z, t);
             }
         };
     }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ROICountLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ROICountLoader.java
@@ -46,8 +46,7 @@ public class ROICountLoader extends BatchCallTree {
             final long imageID) {
         return new BatchCall("Load ROI count from Server") {
             public void doCall() throws Exception {
-                results = context.getGateway().getFacility(ROIFacility.class)
-                        .getROICount(ctx, imageID);
+                results = context.getDataService().getOMEROGateway().getROICount(ctx, imageID);
             }
         };
     }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ROICountLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ROICountLoader.java
@@ -23,7 +23,6 @@
 package org.openmicroscopy.shoola.env.data.views.calls;
 
 import omero.gateway.SecurityContext;
-import omero.gateway.facility.ROIFacility;
 
 import org.openmicroscopy.shoola.env.data.views.BatchCall;
 import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
@@ -46,7 +45,7 @@ public class ROICountLoader extends BatchCallTree {
             final long imageID) {
         return new BatchCall("Load ROI count from Server") {
             public void doCall() throws Exception {
-                results = context.getDataService().getOMEROGateway().getROICount(ctx, imageID);
+                results = context.getDataService().getROICount(ctx, imageID);
             }
         };
     }

--- a/src/test/java/org/openmicroscopy/shoola/env/data/NullOmeroPojoService.java
+++ b/src/test/java/org/openmicroscopy/shoola/env/data/NullOmeroPojoService.java
@@ -285,11 +285,6 @@ public class NullOmeroPojoService
 		return 0;
 	}
 
-	@Override
-	public OMEROGateway getOMEROGateway() {
-		return null;
-	}
-
 	/**
      * No-operation implementation
      * @see OmeroDataService#loadContainerHierarchy(Class, List, boolean, long)

--- a/src/test/java/org/openmicroscopy/shoola/env/data/NullOmeroPojoService.java
+++ b/src/test/java/org/openmicroscopy/shoola/env/data/NullOmeroPojoService.java
@@ -27,9 +27,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import omero.api.StatefulServiceInterfacePrx;
 
+import omero.gateway.model.FolderData;
 import org.openmicroscopy.shoola.env.data.model.DeletableObject;
 import org.openmicroscopy.shoola.env.data.util.SearchDataContext;
 
@@ -283,6 +285,11 @@ public class NullOmeroPojoService
 		return 0;
 	}
 
+	@Override
+	public OMEROGateway getOMEROGateway() {
+		return null;
+	}
+
 	/**
      * No-operation implementation
      * @see OmeroDataService#loadContainerHierarchy(Class, List, boolean, long)
@@ -464,7 +471,17 @@ public class NullOmeroPojoService
             return null;
         }
 
-        /**
+	@Override
+	public Collection<FolderData> saveROIFolders(SecurityContext ctx, Collection<FolderData> folders) throws ExecutionException, DSOutOfServiceException, DSAccessException {
+		return null;
+	}
+
+	@Override
+	public int getROICount(SecurityContext ctx, long imageId) throws DSOutOfServiceException, DSAccessException {
+		return 0;
+	}
+
+	/**
          * No-operation implementation
          * @see OmeroDataService#search(SecurityContext, SearchParameters)
          */
@@ -484,9 +501,7 @@ public class NullOmeroPojoService
             return null;
         }
 
-        @Override
         public Gateway getGateway() {
-            // TODO Auto-generated method stub
             return null;
         }
 }

--- a/src/test/java/org/openmicroscopy/shoola/env/data/NullRenderingService.java
+++ b/src/test/java/org/openmicroscopy/shoola/env/data/NullRenderingService.java
@@ -529,4 +529,9 @@ public class NullRenderingService
             throws DSAccessException, DSOutOfServiceException {
         return null;
     }
+
+	@Override
+	public Map<Integer, int[]> getHistogram(SecurityContext ctx, PixelsData pixels, int[] channels, int z, int t) throws DSAccessException, DSOutOfServiceException {
+		return null;
+	}
 }


### PR DESCRIPTION
Should fix most cases which trigger https://github.com/ome/omero-insight/issues/99 . This PR moves some Java Gateway calls into the OMEROGateway, because there connection issues can be dealt with by trying to reconnect.

Test: Open Insight, login, browse to a dataset with some images, click on one image. Disconnect from the network. Click on another image. Without the PR: Crash with connection exception. With the PR: Reconnection dialog will pop up. Connect to the network again. After a few seconds Insight should have recovered.

~~Note: I made the OMEROGateway class public for convenience,  otherwise I'd have to add another few delegation methods to the OMERODataservice class etc.~~
