### PR TITLE
Add depth option to importer and include ZarrReader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ version = "5.7.3-SNAPSHOT"
 repositories {
     mavenLocal()
     mavenCentral()
+    maven { url 'https://nexus.senbox.net/nexus/content/groups/public/' }
 }
 
 java {
@@ -47,6 +48,9 @@ dependencies {
         // Conflicts with `net.java.dev.jna`
         exclude group: "com.sun.jna", module: "jna"
     }
+    // Add zarr reader
+    implementation("ome:OMEZarrReader:0.3.0")
+    implementation("com.bc.zarr:jzarr:0.3.4")
 }
 
 test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,7 @@ pluginManagement {
         mavenLocal()
         mavenCentral()
         maven { url 'https://artifacts.openmicroscopy.org/artifactory/maven/' }
+        maven { url 'https://nexus.senbox.net/nexus/content/groups/public/' }
     }
 }
 

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/ImporterAgent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/ImporterAgent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -158,18 +158,6 @@ public class ImporterAgent
     { 
         return (ExperimenterData) registry.lookup(
                 LookupNames.CURRENT_USER_DETAILS);
-    }
-
-    /**
-     * Returns how deep to scan when a folder is selected.
-     * 
-     * @return See above.
-     */
-    public static int getScanningDepth()
-    {
-        Integer value = (Integer) registry.lookup("/options/ScanningDepth");
-        if (value == null || value.intValue() < 0) return 1;
-        return value.intValue();
     }
 
     /**

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -214,6 +214,9 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	/** Text for metadata pane */
 	private static final String TEXT_METADATA_DEFAULTS = "Metadata Defaults";
 
+	/** Text for metadata pane */
+	private static final String TEXT_ADVANCED = "Advanced options";
+
 	/** Text for naming panel */
 	private static final String TEXT_DIRECTORIES_BEFORE_FILE =
 			"Directories before File";
@@ -327,6 +330,9 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/** Text field indicating how many folders to include. */
 	private NumericalTextField numberOfFolders;
+
+	/** Text field indicating Bioformats search depth */
+	private NumericalTextField depth;
 
 	/** Button to bring up the tags wizard. */
 	private JButton tagButton;
@@ -671,6 +677,13 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		tagsMap = new LinkedHashMap<JButton, TagAnnotationData>();
 		mapAnnotation=new LinkedHashMap<String,List<MapAnnotationData>>();
 
+		depth = new NumericalTextField();
+		depth.setMinimum(1);
+		depth.setText(System.getProperty("omero.import.depth", "50"));
+		depth.setColumns(4);
+		depth.setToolTipText("Maximum depth Bioformats uses for looking for importable files");
+		depth.addPropertyChangeListener(this);
+
 		IconManager icons = IconManager.getInstance();
 
 		refreshFilesButton = new JButton(TEXT_REFRESH_FILES);
@@ -970,6 +983,15 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		return UIUtilities.buildComponentPanel(p);
 	}
 
+	private JPanel buildAdvancedComponent() {
+		JPanel p = new JPanel();
+		JLabel l = new JLabel();
+		l.setText("Depth: ");
+		p.add(l);
+		p.add(depth);
+		return UIUtilities.buildComponentPanel(p);
+	}
+
 	/**
 	 * Builds and lays out the components displaying the naming options.
 	 *
@@ -1068,9 +1090,14 @@ public class ImportDialog extends ClosableTabbedPaneComponent
         c.gridy = 2;
         options.add(buildPane(TEXT_METADATA_DEFAULTS, buildPixelSizeComponent()), c);
 
+		// Constraints for meta data component
+		c.gridx = 0;
+		c.gridy = 3;
+		options.add(buildPane(TEXT_ADVANCED, buildAdvancedComponent()), c);
+
         // Fills in bottom space of GridBagLayout
         c.gridx = 0;
-        c.gridy = 3;
+        c.gridy = 4;
         c.weighty = 1;
         options.add(new JLabel(" "), c);
 
@@ -1219,7 +1246,6 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 			object.setMapAnnotation(mapAnnotation);
 		}
 
-		object.setScanningDepth(ImporterAgent.getScanningDepth());
 		Boolean loadThumbnails = (Boolean) ImporterAgent.getRegistry()
 				.lookup(LOAD_THUMBNAIL);
 		if (loadThumbnails != null)
@@ -1240,6 +1266,8 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 			}
 			object.setTags(l);
 		}
+
+		object.setDepth((Integer) depth.getValueAsNumber());
 
 		if (partialName.isSelected()) {
 			Integer number = (Integer) numberOfFolders.getValueAsNumber();

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -5874,6 +5874,7 @@ class OMEROGateway
 	 * @param ctx The security context.
 	 * @param object Host information about the file to import.
 	 * @param file The file to import.
+	 * @param status The status tracking object.
 	 * @return See above.
 	 * @throws ImportException If an error occurred while importing.
 	 */
@@ -5895,7 +5896,7 @@ class OMEROGateway
 			reader = new OMEROWrapper(config);
 			String[] paths = new String[1];
 			paths[0] = file.getAbsolutePath();
-			ImportCandidates icans = new ImportCandidates(reader, paths, status);
+			ImportCandidates icans = new ImportCandidates(object.getDepth(), reader, paths, status);
 			
 			for(ImportContainer ic : icans.getContainers()) {
 			    if(object.isOverrideName()) {

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -212,14 +212,6 @@ class OmeroImageServiceImpl
 
 	/**
 	 * Imports the specified candidates.
-	 *
-	 * @param ctx The security context.
-	 * @param status The original status.
-	 * @param object The object hosting information about the import.
-	 * @param list   The list of annotations.
-	 * @param userID The identifier of the user.
-	 * @param hcs Value returns by the import containers.
-	 * @param userName The login name of the user to import for.
 	 */
 	private Object importCandidates(SecurityContext ctx,
 		Map<File, Status> files, Status status,

--- a/src/main/java/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -190,9 +190,6 @@ public class ImportableObject
 	/** The depth when the name is overridden. */
 	private int depthForName;
 
-	/** The depth used when scanning a folder. */
-	private int scanningDepth;
-
 	/**
 	 * Flag indicating to override the name set by B-F when importing the data.
 	 */
@@ -224,6 +221,9 @@ public class ImportableObject
 
 	/** Map of skip options mapping to ImportConfig functions */
 	private Map<String, Object> skipChoices;
+
+	/** The depth Bioformats uses to find the importable files */
+	private int depth = Integer.valueOf(System.getProperty("omero.import.depth", "4"));
 
 	/**
 	 * Returns the object corresponding to the passed file.
@@ -355,24 +355,7 @@ public class ImportableObject
 	{
 		this.mapAnnots=getCloneOfMap(map);
 	}
-	
 
-	/**
-	 * Sets the depth used scanning a folder.
-	 *
-	 * @param scanningDepth The value to set.
-	 */
-	public void setScanningDepth(int scanningDepth)
-	{
-		this.scanningDepth = scanningDepth;
-	}
-
-	/**
-	 * Returns the depth used scanning a folder.
-	 *
-	 * @return See above.
-	 */
-	public int getScanningDepth() { return scanningDepth; }
 
 	/**
 	 * Sets the depth used when the name is overridden.
@@ -764,4 +747,19 @@ public class ImportableObject
         return option != null && !option;
     }
 
+	/**
+	 * Get the depth Bioformats uses to find the importable files
+	 * @return See above
+	 */
+	public int getDepth() {
+		return depth;
+	}
+
+	/**
+	 * Set the depth Bioformats uses to find the importable files
+	 * @param depth The depth
+	 */
+	public void setDepth(int depth) {
+		this.depth = depth;
+	}
 }


### PR DESCRIPTION
This PR adds an additional "depth" option to the importer (with default value 50) and adds the ZarrReader (cherry-picked from #309 , thanks @jburel !).

Test: Import an OME-NGFF Zarr file.
