### PR TITLE
Fix issue 313

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
@@ -945,7 +945,7 @@ class ToolBar
         if (p == null) {
             p = new Point(0, 0);
         };
-        if (c == null) {
+        if (c == null || !c.isShowing()) {
             c = scriptButton;
             repaint();
         }


### PR DESCRIPTION
Fixes issue https://github.com/ome/omero-insight/issues/313 . Tbh, I don't know how these errors happen, because the component must be visible in order for the user to click on it. But at least this will prevent the exception.