### PR TITLE
Add logic to retrieve omero.qa.feedback property server-side

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -519,7 +519,7 @@ public class DataServicesFactory
             }
         } catch (ServerError e) {
             msg = new LogMessage("Server error: ", e);
-            registry.getLogger().warn(this, msg);
+            registry.getLogger().debug(this, msg);
         }
 
         //Post an event to indicate that the user is connected.

--- a/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -518,7 +518,8 @@ public class DataServicesFactory
                 container.getRegistry().bind(LookupNames.PROCESSING_URL, val + "/qa/uploadProcessing/");
             }
         } catch (ServerError e) {
-            msg = new LogMessage("Server error: ", e);
+            msg = new LogMessage();
+            msg.println("Server error: " + e.serverExceptionClass + " - " + e.message);
             registry.getLogger().debug(this, msg);
         }
 

--- a/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -508,6 +508,20 @@ public class DataServicesFactory
             registry.getLogger().warn(this, msg);
         }
 
+        try {
+            String val = cs.getConfigValue("omero.qa.feedback");
+            if (val != null) {
+                msg = new LogMessage();
+                msg.println("Using URL defined server-side for feedback: " + val);
+                registry.getLogger().debug(this, msg);
+                container.getRegistry().bind(LookupNames.TOKEN_URL, val + "/qa/initial/");
+                container.getRegistry().bind(LookupNames.PROCESSING_URL, val + "/qa/uploadProcessing/");
+            }
+        } catch (ServerError e) {
+            msg = new LogMessage("Server error: ", e);
+            registry.getLogger().warn(this, msg);
+        }
+
         //Post an event to indicate that the user is connected.
         EventBus bus = container.getRegistry().getEventBus();
         bus.post(new ConnectedEvent());

--- a/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -510,7 +510,7 @@ public class DataServicesFactory
 
         try {
             String val = cs.getConfigValue("omero.qa.feedback");
-            if (val != null) {
+            if (val != null && !val.isEmpty()) {
                 msg = new LogMessage();
                 msg.println("Using URL defined server-side for feedback: " + val);
                 registry.getLogger().debug(this, msg);


### PR DESCRIPTION
Companion to https://github.com/ome/omero-common/pull/38

Similarly to the logic retrieving the maximum plane width/height from the server, this adds another post-connection step to retrieve the value of the server-side `omero.qa.feedback` property. If defined, it sets the `LookupNames.TOKEN_URL` and `LookupNames.PROCESSING_URL` entries which are used for sending feedback (comments and failed uploads) to the QA server. If the calls fails e.g. with a `SecurityViolation`, the current behavior is unchanged and the default values set in `container.xml` should be used.

Testing should happen in different client/server scenarios:

- OMERO.insight with this PR included against OMERO.server without https://github.com/ome/omero-common/pull/38:
  * if logged in as a normal user, the ConfigService call should throw an exception (logged in the OMERO.insight log file), the default value specified in `container.xml` should be used and the feedback should be sent to the OME QA system
  * if logged in as an admin, the ConfigService call should return an empty string (unless the value has been set) and ignored, the default value specified in `container.xml` should be used and the feedback should be sent to the OME QA system
- OMERO.insight with this PR included against OMERO.server with https://github.com/ome/omero-common/pull/38 included but not value defined for `omero.qa.feedback` server-side: the ConfigService should return the default value, the log file should indicate that `Using URL defined server-side for feedback: http://qa.openmicroscopy.org.uk` and the feedback should be sent to the OME QA system
- (optional) OMERO.insight with this PR included against OMERO.server with https://github.com/ome/omero-common/pull/38 included  and`omero.qa.feedback` set server-side to `http://qa.openmicroscopy.org.uk`: the log file should indicate that `Using URL defined server-side for feedback: http://qa.openmicroscopy.org.uk` and the feedback should be sent to the OME QA system
- OMERO.insight with this PR included against OMERO.server with https://github.com/ome/omero-common/pull/38 included  and`omero.qa.feedback` set server-side to an alternate QA system: the log file should indicate that `Using URL defined server-side for feedback: <alternate QA endpoint>` and the feedback should be sent to the alternate QA system

For each configuration, ideally both comments (Help > Send Feedback) and failed uploads should be tested.