### PR TITLE
DataServicesFactory: only log server exception class and message

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -504,8 +504,9 @@ public class DataServicesFactory
             UpgradeCheck check = new UpgradeCheck(cs.getConfigValue("omero.upgrades.url"), clientVersion, checkname);
             check.run();
         } catch (ServerError e2) {
-            msg = new LogMessage("Could not access ConfigService", e2);
-            registry.getLogger().warn(this, msg);
+            msg = new LogMessage();
+            msg.println("Server error: " + e2.serverExceptionClass + " - " + e2.message);
+            registry.getLogger().debug(this, msg);
         }
 
         try {


### PR DESCRIPTION
Similar to d17677fa6 this avoids printing the entire server stack trace to the log file is the client is talking to an older server where the property is not exposed client-side.