### PR TITLE
Declare logback-classic as explicit dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ dependencies {
         // Conflicts with `net.java.dev.jna`
         exclude group: "com.sun.jna", module: "jna"
     }
-    implementation("ch.qos.logback:logback-classic:1.3.4")
-    implementation("ch.qos.logback:logback-core:1.3.4")
+    implementation("ch.qos.logback:logback-classic:1.3.5")
+    implementation("ch.qos.logback:logback-core:1.3.5")
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
         // Conflicts with `net.java.dev.jna`
         exclude group: "com.sun.jna", module: "jna"
     }
+    implementation("ch.qos.logback:logback-classic:1.3.4")
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
         exclude group: "com.sun.jna", module: "jna"
     }
     implementation("ch.qos.logback:logback-classic:1.3.4")
+    implementation("ch.qos.logback:logback-core:1.3.4")
 }
 
 test {


### PR DESCRIPTION
The work on the upstream ome-* components to declare logback as optional dependencies (following the SLF4J best practice recommendations) has exposed the fact that omero-insight currently has a direct dependency on this logging implementation.

See https://github.com/ome/ome-metakit/pull/11#issuecomment-1386743130