### PR TITLE
Show script menu on toolbar

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
@@ -946,8 +946,7 @@ class ToolBar
             p = new Point(0, 0);
         };
         if (c == null || !c.isShowing()) {
-            c = scriptButton;
-            repaint();
+            c = bar;
         }
         IconManager icons = IconManager.getInstance();
         Collection<ScriptObject> scripts = model.getAvailableScripts();


### PR DESCRIPTION
Fixes issue https://github.com/ome/omero-insight/issues/313 .

The problem is the first time you click on the scripts button, it replaces the script button with a spinner button while loading the available scripts from the server. The script button might not be back in time for the menu to be attached on.

**Test**:
- Replicate the issue with Insight relese version: Start up Insight, click on the "scripts" button. Very likely crash.
- With this PR: No crash. ~~But scripts menu will be shown slightly off to the left of the button on the first click as it is "attached" to the toolbar itself in that case.~~ Not any longer due to @jburel 's adjustment 👍 

