### PR TITLE
Avoid NPE

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -215,8 +215,10 @@ public class ThumbnailLoader extends BatchCallTree {
             int k = 0;
             for (DataObject image : images) {
                 // Cast our image to pixels object
+                if (image == null)
+                    continue;
                 final PixelsData pxd = dataObjectToPixelsData(image);
-                if (image == null || pxd == null || pxd.getImage() == null)
+                if (pxd == null)
                     continue;
 
                 // Flag to check if we've iterated to the last image

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2023 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -216,6 +216,8 @@ public class ThumbnailLoader extends BatchCallTree {
             for (DataObject image : images) {
                 // Cast our image to pixels object
                 final PixelsData pxd = dataObjectToPixelsData(image);
+                if (image == null || pxd == null || pxd.getImage() == null)
+                    continue;
 
                 // Flag to check if we've iterated to the last image
                 final boolean last = lastIndex == k++;


### PR DESCRIPTION
That should "fix" issue https://github.com/ome/omero-insight/issues/343 . Tbh, I don't know how to replicate the issue, nor how it's possible that the pixels or image object is null at that point, but the PR should "fix" the problem by just skipping over this image.
