### PR TITLE
Enable pointing to external container xml

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -87,3 +87,15 @@ You must edit the config file `app\OMERO.insight.cfg` stored in application fold
  - Unzip the app.
  - Open the file ``bin/omero-insight`` in a text editor.
  - Change the value of ``DEFAULT_JVM_OPTS``.
+
+Specify location of container config
+------------------------------------
+You can start Insight with a positional argument pointing to the container xml 
+(e.g. container.xml for the "normal" Insight, containerImport.xml for the Importer).
+In the OSX build this argument is set by OMERO.insight.cfg:
+```
+[ArgOptions]
+container.xml
+```
+This can be either a file name (then Insight will look for it within its `config` directory)
+or a full path.

--- a/src/main/java/org/openmicroscopy/shoola/Main.java
+++ b/src/main/java/org/openmicroscopy/shoola/Main.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.Main
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2022 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2023 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -80,26 +80,6 @@ public class Main
 		List<String> posArgs = Arrays.stream(args).filter(a -> !a.startsWith("--")).collect(Collectors.toList());
 		if (posArgs.size() > 0) configFile = posArgs.get(0);
 		if (posArgs.size() > 1) homeDir = posArgs.get(1);
-
-		try {
-			String path = Container.CONFIG_DIR+ File.separator+Container.CONFIG_FILE;
-			StringBuilder configFileContent = new StringBuilder();
-			try (FileReader fr = new FileReader(path);
-				 BufferedReader br = new BufferedReader(fr)) {
-				 String line = br.readLine();
-				 while (line != null) {
-					 line = br.readLine();
-					 configFileContent.append(line);
-				 }
-			}
-			Matcher m = Pattern.compile("DebugRepaintManager.+?>(.+?)<").matcher(configFileContent.toString());
-			if (m.find() && Boolean.parseBoolean(m.group(1))) {
-					RepaintManager.setCurrentManager(new CheckThreadViolationRepaintManager());
-			}
-		} catch (IOException e) {
-			// Couldn't access config file, just ignore
-		}
-
 		Container.startup(homeDir, configFile, addArgs);
 	}
 	

--- a/src/main/java/org/openmicroscopy/shoola/env/Container.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/Container.java
@@ -1,7 +1,7 @@
 /*
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2021 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2023 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -304,8 +304,13 @@ public final class Container
 	 * @return	See above.
 	 */
 	public String getConfigFileRelative(String file)
-	{ 
-		return getFileRelative(CONFIG_DIR, file);
+	{
+		if (file == null)
+			return null;
+		if (file.contains(File.separator))
+			return file;
+		else
+			return getFileRelative(CONFIG_DIR, file);
 	}
 	
 	/**


### PR DESCRIPTION
Fixes https://github.com/ome/omero-insight/issues/363 .

You can start Insight with a positional argument pointing to the container xml (e.g. container.xml for the "normal" Insight, containerImport.xml for the Importer). In the OSX build this argument is set by OMERO.insight.cfg:
```
[ArgOptions]
container.xml
```

Without this PR the container xml has to be in the config directory within the bundle. With this PR you can point to any location. If the argument contains at least one path character it is assumed it specifies a file outside the bundle, if it doesn't (i.e. it's only a file name) it's assumed that it specifies a file within config directory of the bundle.

The PR also removes the code to enable the DebugRepaintManager, as it's actually not used any more.
