### PR TITLE
Add top-level Git mailmap to normalize commit author variants

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,27 @@
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <workonly@qidane.com>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <A.Tarkowska@dundee.ac.uk> 
+Brian Loranger <bwzloranger@lifesci.dundee.ac.uk>
+Chris Allan <callan@glencoesoftware.com> <callan@blackcat.ca>
+Colin Blackburn <c.blackburn@dundee.ac.uk> <colin@ximenes.org.uk>
+Dominik Lindner <d.lindner@dundee.ac.uk>
+Dominik Lindner <d.lindner@dundee.ac.uk> <dominikl@users.noreply.github.com>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@Grumpy.dyn.lifesci.dundee.ac.uk>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <dzmacdonald@05709c45-44f0-0310-885b-81a1db45b4a6>
+Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
+Jean-Marie Burel <j.burel@dundee.ac.uk> 
+Josh Moore <josh@openmicroscopy.org> <josh.moore@gmx.de>
+Josh Moore <josh@openmicroscopy.org> <j.a.moore@dundee.ac.uk>
+Josh Moore <josh@openmicroscopy.org> <josh@glencoesoftware.com>
+Mark Carroll <m.t.b.carroll@dundee.ac.uk> <M.T.B.Carroll@Dundee.ac.uk>
+Petr Walczysko <p.walczysko@dundee.ac.uk>
+Riad Gozim <r.gozim@dundee.ac.uk> <rgozim1@gmail.com>
+Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@debian.org>
+Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@dundee.ac.uk>
+Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@codelibre.net>
+Scott Littlewood <sylittlewood@dundee.ac.uk> <scottlittlewood@gmail.com>
+Sébastien Besson <sbesson@glencoesoftware.com> <seb.besson@gmail.com>
+Sébastien Simard <ssimard@pasteur.fr>
+Susanne Kunis <susebo@gmail.com>
+Susanne Kunis <susebo@gmail.com> <sukunis@uos.de>
+Will Moore <w.moore@dundee.ac.uk> <will@lifesci.dundee.ac.uk>

--- a/.mailmap
+++ b/.mailmap
@@ -5,8 +5,8 @@ Chris Allan <callan@glencoesoftware.com> <callan@blackcat.ca>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <colin@ximenes.org.uk>
 Dominik Lindner <d.lindner@dundee.ac.uk> dominikl <d.lindner@dundee.ac.uk>
 Dominik Lindner <d.lindner@dundee.ac.uk> <dominikl@users.noreply.github.com>
-Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk>
-Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@Grumpy.dyn.lifesci.dundee.ac.uk>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> dzmacdonald <dzmacdonald@lifesci.dundee.ac.uk>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> donald <donald@Grumpy.dyn.lifesci.dundee.ac.uk>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <dzmacdonald@05709c45-44f0-0310-885b-81a1db45b4a6>
 Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
 Jean-Marie Burel <j.burel@dundee.ac.uk> jburel <j.burel@dundee.ac.uk>
@@ -24,5 +24,5 @@ Scott Littlewood <sylittlewood@dundee.ac.uk> <scottlittlewood@gmail.com>
 Sébastien Besson <sbesson@glencoesoftware.com> <seb.besson@gmail.com>
 Sébastien Simard <ssimard@pasteur.fr> ssimard <ssimard@pasteur.fr>
 Susanne Kunis <susebo@gmail.com> sukunis <susebo@gmail.com>
-Susanne Kunis <susebo@gmail.com> <sukunis@uos.de>
+Susanne Kunis <susebo@gmail.com> sukunis <sukunis@uos.de>
 Will Moore <w.moore@dundee.ac.uk> <will@lifesci.dundee.ac.uk>

--- a/.mailmap
+++ b/.mailmap
@@ -3,25 +3,26 @@ Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <A.Tarkowska@dundee.ac.uk>
 Brian Loranger <bwzloranger@lifesci.dundee.ac.uk>
 Chris Allan <callan@glencoesoftware.com> <callan@blackcat.ca>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <colin@ximenes.org.uk>
-Dominik Lindner <d.lindner@dundee.ac.uk>
+Dominik Lindner <d.lindner@dundee.ac.uk> dominikl <d.lindner@dundee.ac.uk>
 Dominik Lindner <d.lindner@dundee.ac.uk> <dominikl@users.noreply.github.com>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@Grumpy.dyn.lifesci.dundee.ac.uk>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <dzmacdonald@05709c45-44f0-0310-885b-81a1db45b4a6>
 Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
-Jean-Marie Burel <j.burel@dundee.ac.uk> 
+Jean-Marie Burel <j.burel@dundee.ac.uk> jburel <j.burel@dundee.ac.uk>
+Jean-Marie Burel <j.burel@dundee.ac.uk> jean-marie burel <j.burel@dundee.ac.uk>
 Josh Moore <josh@openmicroscopy.org> <josh.moore@gmx.de>
 Josh Moore <josh@openmicroscopy.org> <j.a.moore@dundee.ac.uk>
 Josh Moore <josh@openmicroscopy.org> <josh@glencoesoftware.com>
 Mark Carroll <m.t.b.carroll@dundee.ac.uk> <M.T.B.Carroll@Dundee.ac.uk>
-Petr Walczysko <p.walczysko@dundee.ac.uk>
+Petr Walczysko <p.walczysko@dundee.ac.uk> pwalczysko <p.walczysko@dundee.ac.uk>
 Riad Gozim <r.gozim@dundee.ac.uk> <rgozim1@gmail.com>
 Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@debian.org>
 Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@dundee.ac.uk>
 Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@codelibre.net>
 Scott Littlewood <sylittlewood@dundee.ac.uk> <scottlittlewood@gmail.com>
 Sébastien Besson <sbesson@glencoesoftware.com> <seb.besson@gmail.com>
-Sébastien Simard <ssimard@pasteur.fr>
-Susanne Kunis <susebo@gmail.com>
+Sébastien Simard <ssimard@pasteur.fr> ssimard <ssimard@pasteur.fr>
+Susanne Kunis <susebo@gmail.com> sukunis <susebo@gmail.com>
 Susanne Kunis <susebo@gmail.com> <sukunis@uos.de>
 Will Moore <w.moore@dundee.ac.uk> <will@lifesci.dundee.ac.uk>


### PR DESCRIPTION
This PR adds a top-level mapping file allowing to normalize commits from the same contributor and associate all commits to a canonical "First Name Last Name <email>" author line.

The following rules are used for the construction of the .mailmap file:

- for all contributors who are employees of the University or Dundee, Glencoe Software, the `@dundee.ac.uk`,  or `@glencoesoftware.com` email address is used as the canonical email address
- for all contributors with an executed CLA, the real name and email address sent via the CLA is used as the canonical address
- for all contributors, the name used in https://www.openmicroscopy.org/teams/ or https://www.openmicroscopy.org/contributors/ is used as the canonical real name.

The .mailmap is constructed according to the official [documentation](https://git-scm.com/docs/gitmailmap) using one of the two forms:

```
Proper Name <proper@email.xx> <commit@email.xx>
```

for mapping different email addresses and

```
Proper Name <proper@email.xx> Commit Name <commit@email.xx>
```
for mapping different real names.

The unique list of commit authors can be generated and reviewing using `git shortlog -se`

See also https://github.com/ome/openmicroscopy/pull/6349, https://github.com/ome/bioformats/pull/4026, https://github.com/ome/omero-web/pull/482, https://github.com/ome/omero-py/pull/375 and https://github.com/ome/omero-scripts/pull/208