### PR TITLE
handle Null object when attempting to create an object

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -1669,8 +1669,27 @@ class TreeViewerComponent
 				throw new IllegalStateException("This method cannot be " +
 				"invoked in the DISCARDED state");
 		}
-		if (data == null) 
-			throw new IllegalArgumentException("No data object. ");
+		if (data == null) {
+            setStatus(false, "", true);
+            view.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+            // Notify that the object could not create or
+            String message = "The object could not be ";
+            switch (operation) {
+                case CREATE_OBJECT:
+                    message = message + "created";
+                    break;
+                case UPDATE_OBJECT:
+                	message = message + "updated";
+                    break;
+                case REMOVE_OBJECT:
+                	message = message + "removed";
+                    break;
+
+		   }
+		   TreeViewerAgent.getRegistry().getUserNotifier().notifyWarning("Data handling", message);
+		   return;
+		   //Notify the user
+		}
 		switch (operation) {
 			case CREATE_OBJECT:
 			case UPDATE_OBJECT: 

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java
@@ -321,6 +321,9 @@ class OmeroDataServiceImpl
 			throw new NullPointerException("Cannot convert the object.");
 
 		IObject created = gateway.createObject(ctx, obj, userName);
+		if (created == null) {
+			return null;
+		}
 		IObject link;
 		if (parent != null) {
 			link = ModelMapper.linkParentToChild(created, parent.asIObject());
@@ -342,7 +345,6 @@ class OmeroDataServiceImpl
 			if (links.size() > 0)
 				gateway.createObjects(ctx, links);
 		}
-		
 		return PojoMapper.asDataObject(created);
 	}
 


### PR DESCRIPTION
The easiest way to test this PR
is to return ``null`` instead of the ``pojo`` at https://github.com/ome/omero-insight/blob/master/src/main/java/org/openmicroscopy/shoola/env/data/OmeroDataServiceImpl.java#L346 (now line 348)

see #367