### PR TITLE
Close all HandleTie servants created during import

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -405,6 +405,11 @@ public class FileImportComponent
 	/** Indicates that the import was successful or if it failed.*/
 	private void formatResult()
 	{
+		if (callback != null) {
+			try {
+				((CmdCallbackI) callback).close(true);
+			} catch (Exception e) {}
+		}
 		SwingUtilities.invokeLater(() -> {
 			if (namePane.getPreferredSize().width > LENGTH)
 				fileNameLabel.setText(EditorUtil.getPartialName(
@@ -897,7 +902,7 @@ public class FileImportComponent
 					formatResultTooltip();
 				}
 				else if (image instanceof Collection){
-					Collection<?> c = (Collection)image;
+					Collection<?> c = (Collection) image;
 					if(!c.isEmpty()) {
 						Object obj = c.iterator().next();
 						if(obj instanceof ThumbnailData) {
@@ -966,11 +971,6 @@ public class FileImportComponent
 						FileImportComponent.this.image = null;
 					}
 				}
-				if (callback != null) {
-			        try {
-				        ((CmdCallbackI) callback).close(true);
-			        } catch (Exception e) {}
-		        }
 				FileImportComponent.this.invalidate();
 			}
 		});
@@ -1581,8 +1581,14 @@ public class FileImportComponent
 		});
 	}
 	
+	/**
+	 * Sets the status depending on outcome
+	 */
 	private void setImportResult() {
 		Object result = status.getImportResult();
+		if (result == null) {
+			resultIndex = ImportStatus.FAILURE;
+		}
 		if (image instanceof ImportException) result = image;
 		if (result instanceof ImportException) {
 		    ImportException e = (ImportException) result;
@@ -1593,9 +1599,7 @@ public class FileImportComponent
 			else if (status == ImportException.MISSING_LIBRARY)
 				resultIndex = ImportStatus.FAILURE_LIBRARY;
 			else resultIndex = ImportStatus.FAILURE;
-		} else if (result instanceof CmdCallback) {
-			callback = (CmdCallback) result;
-		} else {
+		} else if (result instanceof Collection) {
 			resultIndex = ImportStatus.SUCCESS;
 		}
 	}

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -405,11 +405,6 @@ public class FileImportComponent
 	/** Indicates that the import was successful or if it failed.*/
 	private void formatResult()
 	{
-		if (callback != null) {
-			try {
-				((CmdCallbackI) callback).close(true);
-			} catch (Exception e) {}
-		}
 		SwingUtilities.invokeLater(() -> {
 			if (namePane.getPreferredSize().width > LENGTH)
 				fileNameLabel.setText(EditorUtil.getPartialName(
@@ -981,6 +976,11 @@ public class FileImportComponent
 						FileImportComponent.this.image = null;
 					}
 				}
+				if (callback != null) {
+			        try {
+				        ((CmdCallbackI) callback).close(true);
+			        } catch (Exception e) {}
+		        }
 				FileImportComponent.this.invalidate();
 			}
 		});

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -418,25 +418,15 @@ public class FileImportComponent
 			refButton = actionMenuButton;
 			addControlsToDisplay();
 			IconManager icons = IconManager.getInstance();
-			Object result = status.getImportResult();
-			if (image instanceof ImportException) result = image;
-			if (result instanceof ImportException) {
-				ImportException e = (ImportException) result;
+			if (image instanceof ImportException) {
+				ImportException e = (ImportException) image;
 				resultLabel.setIcon(icons.getIcon(IconManager.DELETE));
 				resultLabel.setToolTipText(
 						UIUtilities.formatExceptionForToolTip(e));
 				actionMenuButton.setVisible(true);
 				actionMenuButton.setForeground(UIUtilities.REQUIRED_FIELDS_COLOR);
 				actionMenuButton.setText("Failed");
-				int status = e.getStatus();
-				if (status == ImportException.CHECKSUM_MISMATCH)
-					resultIndex = ImportStatus.UPLOAD_FAILURE;
-				else if (status == ImportException.MISSING_LIBRARY)
-					resultIndex = ImportStatus.FAILURE_LIBRARY;
-				else resultIndex = ImportStatus.FAILURE;
-			} else if (result instanceof CmdCallback) {
-				callback = (CmdCallback) result;
-			} else {
+			} else if (resultIndex == ImportStatus.SUCCESS) {
 				formatResultTooltip();
 				resultLabel.setIcon(icons.getIcon(IconManager.APPLY));
 				actionMenuButton.setVisible(true);
@@ -1542,7 +1532,7 @@ public class FileImportComponent
 				if (sl.equals(status)) {
 					if (sl.isMarkedAsCancel()) cancel(true);
 					else {
-						formatResult();
+						setImportResult();
 						firePropertyChange(Status.UPLOAD_DONE_PROPERTY, null,
 								this);
 					}
@@ -1591,6 +1581,25 @@ public class FileImportComponent
 		});
 	}
 	
+	private void setImportResult() {
+		Object result = status.getImportResult();
+		if (image instanceof ImportException) result = image;
+		if (result instanceof ImportException) {
+		    ImportException e = (ImportException) result;
+		    image = result;
+		    int status = e.getStatus();
+		    if (status == ImportException.CHECKSUM_MISMATCH)
+				resultIndex = ImportStatus.UPLOAD_FAILURE;
+			else if (status == ImportException.MISSING_LIBRARY)
+				resultIndex = ImportStatus.FAILURE_LIBRARY;
+			else resultIndex = ImportStatus.FAILURE;
+		} else if (result instanceof CmdCallback) {
+			callback = (CmdCallback) result;
+		} else {
+			resultIndex = ImportStatus.SUCCESS;
+		}
+	}
+
     /**
      * Returns the name of the file and group's id and user's id. 
      * (This String is used as reference to find a specific FileImportComponent

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -133,12 +133,6 @@ public class LightFileImportComponent implements PropertyChangeListener,
 
     /** Indicates that the import was successful or if it failed. */
     private void formatResult() {
-        if (callback != null) {
-            try {
-                ((CmdCallbackI) callback).close(true);
-            } catch (Exception e) {
-            }
-        }
         Object result = status.getImportResult();
         if (image instanceof ImportException)
             result = image;
@@ -433,6 +427,7 @@ public class LightFileImportComponent implements PropertyChangeListener,
     @Override
     public void setStatus(Object image) {
         this.image = image;
+
         if (image instanceof Collection) {
             Collection<?> c = (Collection) image;
             if (!c.isEmpty()) {
@@ -453,6 +448,11 @@ public class LightFileImportComponent implements PropertyChangeListener,
                 resultIndex = ImportStatus.IGNORED;
                 this.image = null;
             }
+        }
+        if (callback != null) {
+            try {
+                ((CmdCallbackI) callback).close(true);
+            } catch (Exception e) {}
         }
     }
 

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -366,7 +366,7 @@ class ImporterModel
 				LogMessage msg = new LogMessage();
                 msg.print("Import closure");
                 msg.print(e);
-				ImporterAgent.getRegistry().getLogger().info(this, msg);
+				ImporterAgent.getRegistry().getLogger().warn(this, msg);
 			}
 		}
 		

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -72,6 +72,7 @@ import omero.gateway.model.ImageData;
 import omero.gateway.model.ProjectData;
 import omero.gateway.model.ROIData;
 import omero.gateway.model.ScreenData;
+import omero.log.LogMessage;
 
 /** 
  * The Model component in the <code>Importer</code> MVC triad.
@@ -356,6 +357,19 @@ class ImporterModel
 	void importCompleted(int loaderID)
 	{
 		state = Importer.READY;
+		ImagesImporter loader = loaders.get(loaderID);
+		if (loader != null) {
+			ImportableObject io = loader.getImportableObject();
+			try {
+				ImporterAgent.getRegistry().getImageService().closeImport(io);
+			} catch (Exception e) {
+				LogMessage msg = new LogMessage();
+                msg.print("Import closure");
+                msg.print(e);
+				ImporterAgent.getRegistry().getLogger().info(this, msg);
+			}
+		}
+		
 	}
 	
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -514,11 +514,13 @@ class ImporterModel
 	        }
         }
 
+        /*
         if (requestThumbnails(component)) {
             ImportResultLoader loader = new ImportResultLoader(this.component,
                     ctx, pixels, type, component);
             loader.load();
         }
+        */
 	}
 	
     /**

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -5852,6 +5852,10 @@ class OMEROGateway
 			try {
 				if (reader != null) reader.close();
 			} catch (Exception ex) {}
+			if (cb != null) {
+				// Allow callback to close handle
+				cb.close(true);
+			}
 
 			handleConnectionException(e);
 			status.markedAsFailed(e);
@@ -5863,9 +5867,6 @@ class OMEROGateway
 			} catch (Exception ex) {}
 			if (omsc != null && close)
 				closeImport(ctx, userName);
-			if (cb != null) {
-				cb.close(true); // Allow callback to close handle
-			}
 		}
 	}
 

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -5800,6 +5800,7 @@ class OMEROGateway
         ic.setUserPixels(object.getPixelsSize());
         OMEROMetadataStoreClient omsc = null;
         OMEROWrapper reader = null;
+        CmdCallbackI cb = null;
 		try {
 			omsc = getImportStore(ctx, userName);
 			reader = new OMEROWrapper(config);
@@ -5845,7 +5846,8 @@ class OMEROGateway
 	        final ImportRequest req = (ImportRequest) handle.getRequest();
 	        final Fileset fs = req.activity.getParent();
 	        status.setFilesetData(new FilesetData(fs));
-	        return library.createCallback(proc, handle, ic);
+	        cb = library.createCallback(proc, handle, ic);
+	        return cb;
 		} catch (Throwable e) {
 			try {
 				if (reader != null) reader.close();
@@ -5861,6 +5863,9 @@ class OMEROGateway
 			} catch (Exception ex) {}
 			if (omsc != null && close)
 				closeImport(ctx, userName);
+			if (cb != null) {
+				cb.close(true); // Allow callback to close handle
+			}
 		}
 	}
 

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageService.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageService.java
@@ -867,4 +867,17 @@ public interface OmeroImageService
 											PixelsData pixels,
 											int[] channels, int z, int t) throws DSAccessException,
 			DSOutOfServiceException;
+
+    /**
+     * Closes the import.
+     * @param ImportableObject The object associated to the import.
+     * @return See above.
+     * @throws DSOutOfServiceException If the connection is broken, or logged
+     *                                  in.
+     * @throws DSAccessException If an error occurred while trying to
+     *                                  retrieve data from OMEDS service.
+     */
+	public void closeImport(ImportableObject object) throws DSAccessException,
+			DSOutOfServiceException;
+
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -1728,7 +1728,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 * @see OmeroImageService#loadAvailableScriptsWithUI(SecurityContext)
 	 */
 	public List<ScriptObject> loadAvailableScriptsWithUI(SecurityContext ctx)
@@ -1738,7 +1738,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 * @see OmeroImageService#loadAvailableScripts(SecurityContext, long)
 	 */
 	public List<ScriptObject> loadAvailableScripts(SecurityContext ctx,
@@ -1749,7 +1749,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 * @see OmeroImageService#loadScript(SecurityContext, long)
 	 */
 	public ScriptObject loadScript(SecurityContext ctx, long scriptID)
@@ -1759,7 +1759,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 * @see OmeroImageService#getScriptsAsString(SecurityContext)
 	 */
 	public Map<Long, String> getScriptsAsString(SecurityContext ctx)
@@ -1769,7 +1769,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 * @see OmeroImageService#uploadScript(SecurityContext, ScriptObject)
 	 */
 	public Object uploadScript(SecurityContext ctx, ScriptObject script)
@@ -1785,7 +1785,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 */
 	public Collection loadROIMeasurements(SecurityContext ctx, Class type,
 		long id, long userID)
@@ -1823,7 +1823,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 * @see OmeroImageService#getFSThumbnailSet(SecurityContext, List, int, long)
 	 */
 	public Map<DataObject, BufferedImage> getFSThumbnailSet(SecurityContext ctx,
@@ -1859,7 +1859,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 * @see OmeroImageService#getExperimenterThumbnailSet(SecurityContext, List, int)
 	 */
 	public Map<DataObject, BufferedImage> getExperimenterThumbnailSet(
@@ -1945,7 +1945,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 * @see OmeroImageService#saveAs(SecurityContext, SaveAsParam)
 	 */
 	public ScriptCallback saveAs(SecurityContext ctx, SaveAsParam param)
@@ -1963,7 +1963,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 * @see OmeroImageService#isLargeImage(SecurityContext, long)
 	 */
 	public Boolean isLargeImage(SecurityContext ctx, long pixelsId)
@@ -1973,7 +1973,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 * @see OmeroImageService#getFileSet(SecurityContext, long)
 	 */
 	public Collection<DataObject> getFileSet(SecurityContext ctx, long imageId)
@@ -1983,7 +1983,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 * @see OmeroImageService#createThumbnailStore(SecurityContext)
 	 */
 	public ThumbnailStorePrx createThumbnailStore(SecurityContext ctx)
@@ -1996,7 +1996,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 * @see OmeroImageService#getRenderingDef(SecurityContext, long, long)
 	 */
 	public Long getRenderingDef(SecurityContext ctx, long pixelsID,
@@ -2009,7 +2009,7 @@ class OmeroImageServiceImpl
 	}
 
 	/**
-	 * Implemented as specified by {@link OmeroDataService}.
+	 * Implemented as specified by {@link OmeroImageService}.
 	 */
 	public RndProxyDef getSettings(SecurityContext ctx, long rndID)
         throws DSOutOfServiceException, DSAccessException
@@ -2021,7 +2021,7 @@ class OmeroImageServiceImpl
     }
 
     /**
-     * Implemented as specified by {@link OmeroDataService}.
+     * Implemented as specified by {@link OmeroImageService}.
      *
      * @see OmeroImageService#createPixelsStore(SecurityContext)
      */
@@ -2032,10 +2032,45 @@ class OmeroImageServiceImpl
         return null;
     }
 
+    /**
+     * Implemented as specified by {@link OmeroImageService}.
+     *
+     * @see OmeroImageService#getHistogram(SecurityContext, PixelsData, int[], int, int)
+     */
 	public Map<Integer, int[]> getHistogram(SecurityContext ctx,
 											PixelsData pixels,
 											int[] channels, int z, int t) throws DSOutOfServiceException,
 			DSAccessException {
 		return gateway.getHistogram(ctx, pixels, channels, z, t);
 	}
+
+    /**
+     * Implemented as specified by {@link OmeroImageService}.
+     *
+     * @see OmeroImageService#closeImport(SecurityContext, String)
+     */
+	public void closeImport(ImportableObject importable) throws DSAccessException,
+			DSOutOfServiceException {
+        if (importable == null) {
+        	return;
+        }
+        List<ImportableFile> files = importable.getFiles();
+        if (files == null || files.size() == 0) {
+        	return;
+        }
+        ImportableFile f = files.get(files.size()-1);
+        SecurityContext ctx = new SecurityContext(f.getGroup().getId());
+		//If import as.
+		ExperimenterData loggedIn = context.getAdminService().getUserDetails();
+		long userID = loggedIn.getId();
+		String userName = null;
+		if (f.getUser() != null) {
+			ExperimenterData exp = f.getUser();
+			userID = exp.getId();
+			if (exp.getId() != loggedIn.getId())
+				userName = exp.getUserName();
+		}
+		gateway.closeImport(ctx, userName);
+	}
+
 }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ImagesImporter.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ImagesImporter.java
@@ -121,7 +121,6 @@ public class ImagesImporter
         while (i.hasNext()) {
             io = i.next();
             final ImportableFile f = io;
-            final boolean b = index == n;
             index++;
             add(new BatchCall("Importing file") {
                 public void doCall() { importFile(f, false); }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ImagesImporter.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ImagesImporter.java
@@ -124,7 +124,7 @@ public class ImagesImporter
             final boolean b = index == n;
             index++;
             add(new BatchCall("Importing file") {
-                public void doCall() { importFile(f, b); }
+                public void doCall() { importFile(f, false); }
             }); 
         }
     }

--- a/src/test/java/org/openmicroscopy/shoola/env/data/NullRenderingService.java
+++ b/src/test/java/org/openmicroscopy/shoola/env/data/NullRenderingService.java
@@ -534,4 +534,8 @@ public class NullRenderingService
 	public Map<Integer, int[]> getHistogram(SecurityContext ctx, PixelsData pixels, int[] channels, int z, int t) throws DSAccessException, DSOutOfServiceException {
 		return null;
 	}
+
+	@Override
+	public void closeImport(ImportableObject importable) throws DSAccessException,
+			DSOutOfServiceException {}
 }


### PR DESCRIPTION
This PR replaces #354

Run an import of one or multiple filesets and watch the creation/deletion of HandleTie servants server-side e.g. using ``tail -F Blitz-0.log  | grep HandleTie.``
All the handles should now be closed and the service closed.
Thumbnails are no longer loaded

To test:
* regular import of single files
* regular import of directories (1-10 & >50 to test the lightfileimport)
* import of broken files (failing server-side)
* import of HCS data
* import of some images which take longer to process on the server side and closing insight before the server side import is finished.

