### PR TITLE
Fix posix issue

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -730,23 +730,23 @@ class ImporterModel
      */
     private File createFile(String imageName)
     {
-    	final String prefix = "ome_";
-        File dir = Files.createTempDirectory(prefix).toFile();
-        String name;
-        String fileName = null;
-        if (object != null) {
-            fileName = object.getTableName();
-        }
-        if (CommonsLangUtils.isBlank(fileName)) {
-            name = "ImageJ-"+FilenameUtils.getBaseName(
-                    FilenameUtils.removeExtension(imageName))+"-Results-";
-            name += new SimpleDateFormat("yyyy-MM-dd").format(new Date());
-        } else {
-            name = FilenameUtils.removeExtension(fileName);
-        }
-        
-        name += ".csv";
         try {
+            final String prefix = "ome_";
+            File dir = Files.createTempDirectory(prefix).toFile();
+            String name;
+            String fileName = null;
+            if (object != null) {
+                fileName = object.getTableName();
+            }
+            if (CommonsLangUtils.isBlank(fileName)) {
+                name = "ImageJ-"+FilenameUtils.getBaseName(
+                    FilenameUtils.removeExtension(imageName))+"-Results-";
+                name += new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+            } else {
+                name = FilenameUtils.removeExtension(fileName);
+            }
+        
+            name += ".csv";
             File f = new File(dir, name);
             //read data
             ROIReader reader = new ROIReader();

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -24,6 +24,7 @@ import ij.ImagePlus;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -61,8 +62,6 @@ import omero.gateway.SecurityContext;
 
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.roi.io.ROIReader;
-
-import com.google.common.io.Files;
 
 import omero.gateway.model.DataObject;
 import omero.gateway.model.ExperimenterData;
@@ -731,7 +730,8 @@ class ImporterModel
      */
     private File createFile(String imageName)
     {
-        File dir = Files.createTempDir();
+    	final String prefix = "ome_";
+        File dir = Files.createTempDirectory(prefix).toFile();
         String name;
         String fileName = null;
         if (object != null) {

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ArchivedImageLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ArchivedImageLoader.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import java.nio.file.Files;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FileUtils;
@@ -174,7 +175,7 @@ public class ArchivedImageLoader
                     
                     result = new HashMap<Boolean, List<File>>();
                     
-                    if(CollectionUtils.isEmpty(files))
+                    if (CollectionUtils.isEmpty(files))
                         return;
                     
                     if (zip) {
@@ -186,7 +187,7 @@ public class ArchivedImageLoader
                         File to = new File(f.getParentFile(), baseName
                                 + "."
                                 + FilenameUtils.getExtension(f.getName()));
-                        Files.move(f, to);
+                        Files.move(f, to, REPLACE_EXISTING);
                         f = copyFile(to, folder.getParentFile());
                         ((Map<Boolean, List<File>>)result).put(Boolean.TRUE, Arrays.asList(f));
                     }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ArchivedImageLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ArchivedImageLoader.java
@@ -30,7 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -158,8 +159,8 @@ public class ArchivedImageLoader
                 
                 File tmpFolder = null;
                 try {
-                    if(zip)
-                        tmpFolder = Files.createTempDir();
+                    if (zip)
+                        tmpFolder = Files.createTempDirectory("ome_").toFile();
                     else
                         tmpFolder = folder;
                     

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ArchivedImageLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ArchivedImageLoader.java
@@ -187,7 +187,7 @@ public class ArchivedImageLoader
                         File to = new File(f.getParentFile(), baseName
                                 + "."
                                 + FilenameUtils.getExtension(f.getName()));
-                        Files.move(f, to, REPLACE_EXISTING);
+                        Files.move(f.toPath(), to.toPath(), REPLACE_EXISTING);
                         f = copyFile(to, folder.getParentFile());
                         ((Map<Boolean, List<File>>)result).put(Boolean.TRUE, Arrays.asList(f));
                     }

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/FileUploader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/FileUploader.java
@@ -30,7 +30,7 @@ import omero.model.OriginalFile;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.OmeroMetadataService;
@@ -126,7 +126,7 @@ public class FileUploader
 					}
 				}
 				if (b || id > 0) {
-					directory = Files.createTempDir();
+					directory = Files.createTempDirectory("ome_").toFile();
 					//Add the file to the directory.
 					if (f != null) {
 						directory = new File(directory.getParentFile(),

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ResultsSaver.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ResultsSaver.java
@@ -84,17 +84,17 @@ public class ResultsSaver
      */
     private File createFile(ImagePlus img, String fileName)
     {
-        File dir = Files.createTempDirectory("ome_").toFile();
-        String name;
-        if (CommonsLangUtils.isBlank(fileName)) {
-            name = "ImageJ-"+FilenameUtils.getBaseName(
-                    FilenameUtils.removeExtension(img.getTitle()))+"-Results-";
-            name += new SimpleDateFormat("yyyy-MM-dd").format(new Date());
-        } else {
-            name = FilenameUtils.removeExtension(fileName);
-        }
-        name += ".csv";
         try {
+            File dir = Files.createTempDirectory("ome_").toFile();
+            String name;
+            if (CommonsLangUtils.isBlank(fileName)) {
+                name = "ImageJ-"+FilenameUtils.getBaseName(
+                    FilenameUtils.removeExtension(img.getTitle()))+"-Results-";
+                name += new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+            } else {
+                name = FilenameUtils.removeExtension(fileName);
+            }
+            name += ".csv";
             File f = new File(dir, name);
             //read data
             ROIReader reader = new ROIReader();

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ResultsSaver.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ResultsSaver.java
@@ -24,6 +24,7 @@ import ij.IJ;
 import ij.ImagePlus;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Iterator;
@@ -41,7 +42,7 @@ import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.roi.io.ROIReader;
 
-import com.google.common.io.Files;
+
 
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.FileAnnotationData;
@@ -83,7 +84,7 @@ public class ResultsSaver
      */
     private File createFile(ImagePlus img, String fileName)
     {
-        File dir = Files.createTempDir();
+        File dir = Files.createTempDirectory("ome_").toFile();
         String name;
         if (CommonsLangUtils.isBlank(fileName)) {
             name = "ImageJ-"+FilenameUtils.getBaseName(

--- a/src/test/java/org/openmicroscopy/shoola/util/file/TestIOUtil.java
+++ b/src/test/java/org/openmicroscopy/shoola/util/file/TestIOUtil.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.zip.ZipEntry;
@@ -33,8 +34,6 @@ import java.util.zip.ZipInputStream;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-
-import com.google.common.io.Files;
 
 import junit.framework.TestCase;
 
@@ -136,11 +135,12 @@ public class TestIOUtil
     public void testZipDirectory()
     {
         try {
-            File dir = Files.createTempDir();
+            final String prefix = "test_ome";
+            File dir = Files.createTempDirectory(prefix).toFile();
             File f = File.createTempFile("testZipDirectory", ".tmp", dir);
             File zip = IOUtil.zipDirectory(dir);
             assertEquals(FilenameUtils.getExtension(zip.getName()), "zip");
-            File destDir = Files.createTempDir();
+            File destDir = Files.createTempDirectory(prefix).toFile();
             boolean b = unzip(zip, destDir);
             assertEquals(true, b);
             File[] files = destDir.listFiles();
@@ -159,15 +159,16 @@ public class TestIOUtil
     public void testZipDirectoryWithSubfolder()
     {
         try {
-            File dir = Files.createTempDir();
+            final String prefix = "test_ome";
+            File dir = Files.createTempDirectory(prefix).toFile();
             File f = File.createTempFile("testZipDirectoryWithSubfolder", ".tmp", dir);
-            File subfolder = Files.createTempDir();
+            File subfolder = Files.createTempDirectory(prefix).toFile();
             File f1 = File.createTempFile("sub_testZipDirectoryWithSubfolder", ".tmp", subfolder);
 
             FileUtils.moveDirectoryToDirectory(subfolder, dir, false);
 
             File zip = IOUtil.zipDirectory(dir);
-            File destDir = Files.createTempDir();
+            File destDir = Files.createTempDirectory(prefix).toFile();
             boolean b = unzip(zip, destDir);
             assertEquals(true, b);
             File[] files = destDir.listFiles();


### PR DESCRIPTION
2 tests are currently failing on Windows see https://github.com/ome/omero-insight/pull/416
with the error
```
java.lang.UnsupportedOperationException: 'posix:permissions' not supported as initial attribute
    	at sun.nio.fs.WindowsSecurityDescriptor.fromAttribute(WindowsSecurityDescriptor.java:358)
    	at sun.nio.fs.WindowsFileSystemProvider.createDirectory(WindowsFileSystemProvider.java:492)
    	at java.nio.file.Files.createDirectory(Files.java:674)
    	at java.nio.file.TempFileHelper.create(TempFileHelper.java:136)
    	at java.nio.file.TempFileHelper.createTempDirectory(TempFileHelper.java:173)
    	at java.nio.file.Files.createTempDirectory(Files.java:950)
    	at com.google.common.io.TempFileCreator$JavaNioCreator.createTempDir(TempFileCreator.java:102)
    	at com.google.common.io.Files.createTempDir(Files.java:439)
```

This PR replaces the usage of ``com.google.common.io.Files`` directly by ``java.nio.file.Files.``
This PR is required to release a new version of omero-insigth