### PR TITLE
Remove apache commons io

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,10 @@ repositories {
     mavenCentral()
 }
 
+configurations.all {
+    exclude group: 'commons-io'
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/ChecksumTableRenderer.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/ChecksumTableRenderer.java
@@ -27,6 +27,7 @@ package org.openmicroscopy.shoola.agents.fsimporter.util;
 //Java imports
 import java.awt.Color;
 import java.awt.Component;
+import java.nio.file.Paths;
 import javax.swing.Icon;
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
@@ -35,7 +36,6 @@ import javax.swing.table.DefaultTableCellRenderer;
 //Third-party libraries
 
 //Application-internal dependencies
-import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 /**
@@ -107,7 +107,7 @@ class ChecksumTableRenderer
 					setText(v.substring(0, MAX_CHARACTERS));
 				else setText(v);
 			} else {
-				setText(FilenameUtils.getName(v));
+				setText(Paths.get(v).getFileName().toString());
 			}
 		}
 		return this;

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -61,7 +61,6 @@ import omero.cmd.CmdCallback;
 import omero.cmd.CmdCallbackI;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.FileUtils;
 import org.jdesktop.swingx.JXBusyLabel;
 import org.jdesktop.swingx.JXTaskPane;
 import org.openmicroscopy.shoola.agents.events.importer.BrowseContainer;
@@ -80,6 +79,7 @@ import org.openmicroscopy.shoola.env.data.model.ThumbnailData;
 import org.openmicroscopy.shoola.env.data.util.Status;
 import org.openmicroscopy.shoola.env.data.util.StatusLabel;
 import org.openmicroscopy.shoola.env.event.EventBus;
+import org.openmicroscopy.shoola.util.file.IOUtil;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
@@ -363,7 +363,7 @@ public class FileImportComponent
 			}
 		}
 		buf.append("<b>Size: </b>");
-		buf.append(FileUtils.byteCountToDisplaySize(status.getSizeUpload()));
+		buf.append(IOUtil.byteCountToDisplaySize(status.getSizeUpload()));
 		buf.append("<br>");
 		buf.append("<b>Group: </b>");
 		buf.append(importable.getGroup().getName());

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -20,9 +20,12 @@
  */
 package org.openmicroscopy.shoola.agents.fsimporter.view;
 
+import com.google.common.io.MoreFiles;
 import ij.ImagePlus;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.nio.file.Files;
 import java.util.Collection;
@@ -39,7 +42,6 @@ import javax.swing.filechooser.FileFilter;
 import omero.model.ImageI;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.agents.fsimporter.AnnotationDataLoader;
 import org.openmicroscopy.shoola.agents.fsimporter.DataLoader;
 import org.openmicroscopy.shoola.agents.fsimporter.DataObjectCreator;
@@ -203,7 +205,7 @@ class ImporterModel
 	/** 
 	 * Creates a new instance.
 	 *
-	 * @param groupID The id to the group selected for the current user.
+	 * @param groupId The id to the group selected for the current user.
 	 * @param displayMode Group/Experimenter view.
 	 */
 	ImporterModel(long groupId, int displayMode)
@@ -214,7 +216,7 @@ class ImporterModel
 	/** 
 	 * Creates a new instance.
 	 *
-	 * @param groupID The id to the group selected for the current user.
+	 * @param groupId The id to the group selected for the current user.
 	 * @param master Pass <code>true</code> if the importer is used a stand-alone
 	 * application, <code>false</code> otherwise.
 	 * @param displayMode Group/Experimenter view.
@@ -381,7 +383,7 @@ class ImporterModel
 	/**
 	 * Sets the collection of the existing tags.
 	 * 
-	 * @param The value to set.
+	 * @param tags The value to set.
 	 */
 	void setTags(Collection tags)
 	{ 
@@ -739,11 +741,11 @@ class ImporterModel
                 fileName = object.getTableName();
             }
             if (CommonsLangUtils.isBlank(fileName)) {
-                name = "ImageJ-"+FilenameUtils.getBaseName(
-                    FilenameUtils.removeExtension(imageName))+"-Results-";
+				Path baseName = Paths.get(imageName).getFileName();
+                name = "ImageJ-"+MoreFiles.getNameWithoutExtension(baseName)+"-Results-";
                 name += new SimpleDateFormat("yyyy-MM-dd").format(new Date());
             } else {
-                name = FilenameUtils.removeExtension(fileName);
+                name = MoreFiles.getNameWithoutExtension(Paths.get(fileName));
             }
         
             name += ".csv";

--- a/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -59,7 +59,6 @@ import omero.gateway.model.ScreenData;
 import omero.gateway.model.TagAnnotationData;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.FileUtils;
 import org.jdesktop.swingx.JXBusyLabel;
 import org.openmicroscopy.shoola.agents.fsimporter.IconManager;
 import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
@@ -75,6 +74,7 @@ import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
+import org.openmicroscopy.shoola.util.file.IOUtil;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;
 import org.openmicroscopy.shoola.util.ui.ClosableTabbedPaneComponent;
 import org.openmicroscopy.shoola.util.ui.RotationIcon;
@@ -517,7 +517,7 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
     JPanel buildHeader()
     {
         sizeLabel = UIUtilities.createComponent(null);
-        sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
+        sizeLabel.setText(IOUtil.byteCountToDisplaySize(sizeImport));
         reportLabel = UIUtilities.setTextFont("Report:", Font.BOLD);
         importSizeLabel = UIUtilities.setTextFont("Import Size:", Font.BOLD);
         
@@ -638,7 +638,7 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
         if (file.isFile()) {
             countUploaded++;
             sizeImport += c.getImportSize();
-            sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
+            sizeLabel.setText(IOUtil.byteCountToDisplaySize(sizeImport));
             // handle error that occurred during the scanning or upload.
             // Check that the result has not been set.
             // if (!c.hasResult()) {
@@ -718,7 +718,7 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
             if (fc.hasUploadFailed()) {
                 countUploadFailure++;
                 sizeImport -= fc.getImportSize();
-                sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
+                sizeLabel.setText(IOUtil.byteCountToDisplaySize(sizeImport));
             }
             if (fc.hasImportFailed())
                 countFailure++;

--- a/src/main/java/org/openmicroscopy/shoola/agents/imviewer/util/saver/ImgSaver.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/imviewer/util/saver/ImgSaver.java
@@ -34,13 +34,14 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 
-import org.apache.commons.io.FileUtils;
 import org.openmicroscopy.shoola.agents.imviewer.ImViewerAgent;
 import org.openmicroscopy.shoola.agents.imviewer.util.ImagePaintingFactory;
 import org.openmicroscopy.shoola.agents.imviewer.view.ImViewer;
@@ -486,7 +487,7 @@ public class ImgSaver
         	String name = uiDelegate.getSelectedFilePath();
         	
         	// make sure the parent directory paths all exist
-        	FileUtils.forceMkdir(new File(name).getParentFile());
+            Files.createDirectories(Paths.get(new File(name).getParentFile().toURI()));
         	
             if (imageComponents == null) {
                 if (mainImage == null) return;

--- a/src/main/java/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -28,6 +28,7 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -38,13 +39,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.io.MoreFiles;
 import omero.model.Length;
 import omero.model.LengthI;
 import omero.model.PlaneInfo;
 import omero.model.enums.UnitsLength;
 import omero.romio.PlaneDef;
 
-import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.agents.events.iviewer.CopyRndSettings;
 import org.openmicroscopy.shoola.agents.imviewer.AcquisitionDataLoader;
 import org.openmicroscopy.shoola.agents.imviewer.BirdEyeLoader;
@@ -2199,7 +2200,7 @@ class ImViewerModel
 	 * @return See above.
 	 */
 	private String combineFilenameWith(String projectName, String imageName) {
-		String extension = FilenameUtils.getExtension(imageName);
+		String extension = MoreFiles.getFileExtension(Paths.get(imageName));
 		
 		StringBuilder nameBuilder = new StringBuilder();
 		nameBuilder.append(projectName);

--- a/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/OriginalMetadataComponent.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/metadata/editor/OriginalMetadataComponent.java
@@ -30,6 +30,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -49,8 +50,8 @@ import javax.swing.JSeparator;
 import javax.swing.JToolBar;
 import javax.swing.table.DefaultTableModel;
 
+import com.google.common.io.MoreFiles;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.jdesktop.swingx.JXBusyLabel;
 import org.jdesktop.swingx.JXTable;
@@ -121,7 +122,7 @@ class OriginalMetadataComponent
         if (data != null) name = data.getFileName();
         else {
             ImageData img = model.getImage();
-            name = FilenameUtils.removeExtension(img.getName());
+            name = MoreFiles.getNameWithoutExtension(Paths.get(img.getName()));
         }
         chooser.setSelectedFileFull(name);
         chooser.setApproveButtonText("Download");

--- a/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
@@ -39,6 +39,7 @@ import java.awt.event.MouseListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeListenerProxy;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -69,7 +70,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.BevelBorder;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.jdesktop.swingx.JXBusyLabel;
 import org.openmicroscopy.shoola.agents.treeviewer.IconManager;
 import org.openmicroscopy.shoola.agents.treeviewer.TreeViewerAgent;
@@ -1015,7 +1015,7 @@ class ToolBar
                 value = "";
                 path = so.getPath();
                 if (path != null && path.length() > 1) {
-                    sep = FilenameUtils.getPrefix(path);
+                    sep = Paths.get(path).getRoot().toString();
                     if (path.startsWith(sep))
                         path = path.substring(1, path.length());
                     values = UIUtilities.splitString(path);
@@ -1036,7 +1036,7 @@ class ToolBar
                 so = i.next();
                 path = so.getPath();
                 if (path != null) {
-                    sep = FilenameUtils.getPrefix(path);
+                    sep = Paths.get(path).getRoot().toString();
                     if (path.startsWith(sep))
                         path = path.substring(1, path.length());
                     values = UIUtilities.splitString(path);

--- a/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerFactory.java
+++ b/src/main/java/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerFactory.java
@@ -27,6 +27,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -42,7 +43,6 @@ import javax.swing.JMenu;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
-import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.agents.events.SaveData;
 import org.openmicroscopy.shoola.agents.treeviewer.TreeViewerAgent;
 import org.openmicroscopy.shoola.env.Agent;
@@ -442,7 +442,7 @@ public class TreeViewerFactory
 		
 		Environment env = (Environment) 
 		TreeViewerAgent.getRegistry().lookup(LookupNames.ENV);
-		String name = FilenameUtils.concat(env.getOmeroHome(),FILE_NAME);
+		String name = Paths.get(env.getOmeroHome(), FILE_NAME).toString();
 		
 		File f = new File(name);
 		if (!f.exists()) return;

--- a/src/main/java/org/openmicroscopy/shoola/env/Container.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/Container.java
@@ -23,12 +23,13 @@
 package org.openmicroscopy.shoola.env;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.io.FilenameUtils;
+import com.google.common.io.MoreFiles;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.env.config.AgentInfo;
 import org.openmicroscopy.shoola.env.config.Registry;
@@ -247,12 +248,13 @@ public final class Container
 	private Container(String home, String configFile, String pluginDir, List<String> cmdLineArgs)
 		throws StartupException
 	{
-	    if (CommonsLangUtils.isBlank(configFile) || !FilenameUtils.isExtension(configFile, "xml")) {
+	    if (CommonsLangUtils.isBlank(configFile) ||
+				!MoreFiles.getFileExtension(Paths.get(configFile)).toLowerCase().equals("xml")) {
 			configFile = CONFIG_FILE;
 		}
 		this.configFile = configFile;
 
-        if (CommonsLangUtils.isBlank(FilenameUtils.getPath(home))) {
+        if (CommonsLangUtils.isBlank(home)) {
         	home = System.getProperty("user.dir");
 		}
         File f = new File(home);
@@ -465,7 +467,7 @@ public final class Container
 	 * plug-in. Those plug-in will have an UI entry.
 	 * @param pluginDir  Path to the plugin directory. Used in plugin mode only.
 	 * @return A reference to the newly created singleton Container.
-	 * @throws Throws a startup exception if the application cannot be used as
+	 * @throws StartupException Throws a startup exception if the application cannot be used as
 	 * a plugin due to missing dependencies.
 	 */
 	public static Container startupInPluginMode(String home, String configFile,
@@ -493,7 +495,7 @@ public final class Container
      * @param plugin Pass positive value. See {@link LookupNames} for supported
      * plug-in. Those plug-in will have an UI entry.
      * @return A reference to the newly created singleton Container.
-     * @throws Throws a startup exception if the application cannot be used as 
+     * @throws StartupException Throws a startup exception if the application cannot be used as
      * a plugin due to missing dependencies.
      */
     public static Container startupInPluginMode(String home, String configFile,
@@ -522,7 +524,7 @@ public final class Container
 	 * plug-in. Those plug-in will have an UI entry.
 	 * @param listener Listens to <code>ConnectedEvent</code>.
 	 * @return A reference to the newly created singleton Container.
-	 * @throws Throws a startup exception if the application cannot be used as
+	 * @throws StartupException Throws a startup exception if the application cannot be used as
 	 * a plugin due to missing dependencies.
 	 */
 	public static Container startupInPluginMode(String home, String configFile,
@@ -552,7 +554,7 @@ public final class Container
      * plug-in. Those plug-in will have an UI entry.
      * @param listener Listens to <code>ConnectedEvent</code>.
      * @return A reference to the newly created singleton Container.
-     * @throws Throws a startup exception if the application cannot be used as 
+     * @throws StartupException Throws a startup exception if the application cannot be used as
      * a plugin due to missing dependencies.
      */
     public static Container startupInPluginMode(String home, String configFile,
@@ -637,7 +639,7 @@ public final class Container
      * @param plugin Pass positive value. See {@link LookupNames} for supported
      * plug-in. Those plug-in will have an UI entry.
      * @return A reference to the newly created singleton Container.
-     * @throws Throws a startup exception if the application cannot be used as 
+     * @throws StartupException Throws a startup exception if the application cannot be used as
      * a plugin due to missing dependencies.
      */
     public static Container startupInHeadlessMode(String home,
@@ -695,7 +697,7 @@ public final class Container
      *              empty, then the user directory is assumed.
      * @param configFile The configuration file.
      * @return A reference to the newly created singleton Container.
-     * @throws Throws a startup exception if the application cannot be used as 
+     * @throws StartupException Throws a startup exception if the application cannot be used as
      * a plugin due to missing dependencies.
      */
     public static Container startupInHeadlessMode(String home, String configFile

--- a/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -26,6 +26,9 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -77,7 +80,6 @@ import omero.romio.PlaneDef;
 import omero.sys.Parameters;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.RandomStringUtils;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.config.Registry;
@@ -1580,7 +1582,7 @@ class OmeroImageServiceImpl
         }
         File f = File.createTempFile(
                 RandomStringUtils.random(60, false, true), "."+XMLFilter.OME_XML);
-        FileUtils.copyFile(inputXML, f);
+        Files.copy(inputXML.toPath(), f.toPath());
         return f;
     }
 
@@ -1632,7 +1634,7 @@ class OmeroImageServiceImpl
 				tmp = File.createTempFile(RandomStringUtils.random(60, false, true),
 	                    "."+XMLFilter.OME_XML);
 				String c = new TiffParser(file.getAbsolutePath()).getComment();
-				FileUtils.writeStringToFile(tmp, c, encoding);
+				Files.write(tmp.toPath(), c.getBytes(Charset.forName(encoding)));
 				transformed = applyTransforms(tmp, transforms, encoding);
 			} else {
 			    transformed = applyTransforms(file, transforms, encoding);
@@ -1641,13 +1643,13 @@ class OmeroImageServiceImpl
 			if (index == EXPORT_AS_OME_XML) {
 			    file.delete();
 			    r = new File(path);
-			    FileUtils.copyFile(transformed, r);
+				Files.copy(transformed.toPath(), r.toPath());
 			    return r;
 			} else {
 				TiffSaver saver = new TiffSaver(file.getAbsolutePath());
 				ra = new RandomAccessInputStream(file.getAbsolutePath());
 				saver.overwriteComment(ra,
-				        FileUtils.readFileToString(transformed, encoding));
+						Files.readString(transformed.toPath(), Charset.forName(encoding)));
 				return file;
 			}
 		} catch (Exception e) {
@@ -2046,8 +2048,6 @@ class OmeroImageServiceImpl
 
     /**
      * Implemented as specified by {@link OmeroImageService}.
-     *
-     * @see OmeroImageService#closeImport(SecurityContext, String)
      */
 	public void closeImport(ImportableObject importable) throws DSAccessException,
 			DSOutOfServiceException {

--- a/src/main/java/org/openmicroscopy/shoola/env/data/model/FileObject.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/model/FileObject.java
@@ -21,17 +21,21 @@
 package org.openmicroscopy.shoola.env.data.model;
 
 
+import com.google.common.io.MoreFiles;
 import ij.IJ;
 import ij.ImagePlus;
 import ij.io.FileInfo;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,9 +45,8 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import loci.formats.codec.CompressionType;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
+import org.openmicroscopy.shoola.util.file.IOUtil;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -414,15 +417,14 @@ public class FileObject
                 if (info != null) {
                     if (CommonsLangUtils.isNotEmpty(info.url)) {
                         //create a tmp file and copy the URL
-                        String fname = img.getTitle();
-                        String extension = FilenameUtils.getExtension(fname);
-                        String baseName = FilenameUtils.getBaseName(
-                                FilenameUtils.removeExtension(fname));
+                        Path fname = Paths.get(img.getTitle());
+                        String extension = MoreFiles.getFileExtension(fname);
+                        String baseName = MoreFiles.getNameWithoutExtension(fname);
                         try {
                             trueFile = File.createTempFile(baseName,
                                     "."+extension);
                             trueFile.deleteOnExit();
-                            FileUtils.copyURLToFile(new URL(info.url), trueFile);
+                            Files.copy(new URL(info.url).openStream(), trueFile.toPath());
                         } catch (Exception e) {
                             //ignore.
                         }
@@ -461,7 +463,7 @@ public class FileObject
         if (file instanceof File) {
             f = (File) file;
             if (f.isFile()) return f.length();
-            return FileUtils.sizeOfDirectory(f);
+            return IOUtil.sizeOfDirectory(f.getAbsolutePath());
         } else if (file instanceof ImagePlus) {
             f = getTrueFile();
             if (f != null) return f.length();

--- a/src/main/java/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
@@ -22,6 +22,7 @@ package org.openmicroscopy.shoola.env.data.model;
 
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -32,13 +33,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.io.MoreFiles;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 import loci.formats.in.OMEXMLReader;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.FilenameUtils;
 
 import omero.gateway.SecurityContext;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
@@ -171,7 +172,7 @@ public class ImportableObject
 		if (f == null) return false;
 		String name = f.getName();
 		if (!name.contains(".")) return false;
-		String ext = FilenameUtils.getExtension(name);
+		String ext = MoreFiles.getFileExtension(Paths.get(name));
 		return ARBITRARY_FILES_EXTENSION.contains(ext);
 	}
 

--- a/src/main/java/org/openmicroscopy/shoola/env/data/model/appdata/LinuxApplicationDataExtractor.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/model/appdata/LinuxApplicationDataExtractor.java
@@ -24,11 +24,12 @@ package org.openmicroscopy.shoola.env.data.model.appdata;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URL;
+import java.nio.file.Paths;
 
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 
-import org.apache.commons.io.FilenameUtils;
+import com.google.common.io.MoreFiles;
 import org.openmicroscopy.shoola.env.data.model.ApplicationData;
 
 /**
@@ -71,7 +72,7 @@ public class LinuxApplicationDataExtractor implements ApplicationDataExtractor
 	public ApplicationData extractAppData(File file) throws Exception {
 		String applicationPath = file.getAbsolutePath();
 
-		String applicationName = FilenameUtils.getBaseName(applicationPath);
+		String applicationName = MoreFiles.getNameWithoutExtension(Paths.get(applicationPath));
 
 		// TODO: read the location of this from .desktop file
 		Icon applicationIcon = new ImageIcon();

--- a/src/main/java/org/openmicroscopy/shoola/env/data/model/appdata/WindowsApplicationDataExtractor.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/model/appdata/WindowsApplicationDataExtractor.java
@@ -26,11 +26,12 @@ package org.openmicroscopy.shoola.env.data.model.appdata;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URL;
+import java.nio.file.Paths;
 
 import javax.swing.Icon;
 import javax.swing.filechooser.FileSystemView;
 
-import org.apache.commons.io.FilenameUtils;
+import com.google.common.io.MoreFiles;
 import org.openmicroscopy.shoola.env.data.model.ApplicationData;
 
 import com.sun.jna.Memory;
@@ -236,7 +237,7 @@ public class WindowsApplicationDataExtractor implements
 		int fileVersionInfoSize = Version.INSTANCE
 				.GetFileVersionInfoSize(absPath, dwDummy);
 
-		String applicationName = FilenameUtils.getBaseName(absPath);
+		String applicationName = MoreFiles.getNameWithoutExtension(Paths.get(absPath));
 
 		if (fileVersionInfoSize > 0) {
 			String translation = getTranslation(absPath, fileVersionInfoSize);

--- a/src/main/java/org/openmicroscopy/shoola/env/data/util/Status.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/util/Status.java
@@ -41,10 +41,10 @@ import omero.gateway.model.FilesetData;
 import omero.gateway.model.PixelsData;
 import omero.gateway.util.PojoMapper;
 
-import org.apache.commons.io.FileUtils;
 import org.openmicroscopy.shoola.env.data.ImportException;
 import org.openmicroscopy.shoola.env.data.model.FileObject;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
+import org.openmicroscopy.shoola.util.file.IOUtil;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 /**
@@ -229,7 +229,7 @@ public class Status implements IObserver {
      */
     private String formatUpload(long value) {
         StringBuffer buffer = new StringBuffer();
-        String v = FileUtils.byteCountToDisplaySize(value);
+        String v = IOUtil.byteCountToDisplaySize(value);
         String[] values = v.split(" ");
         if (values.length > 1) {
             String u = values[1];
@@ -327,7 +327,7 @@ public class Status implements IObserver {
         for (int i = 0; i < usedFiles.length; i++) {
             sizeUpload += (new File(usedFiles[i])).length();
         }
-        fileSize = FileUtils.byteCountToDisplaySize(sizeUpload);
+        fileSize = IOUtil.byteCountToDisplaySize(sizeUpload);
         String[] values = fileSize.split(" ");
         if (values.length > 1)
             units = values[1];

--- a/src/main/java/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
@@ -39,9 +39,9 @@ import ome.formats.importer.ImportCandidates;
 import ome.formats.importer.ImportEvent;
 import ome.formats.importer.util.ErrorHandler;
 
-import org.apache.commons.io.FileUtils;
 import org.openmicroscopy.shoola.env.data.ImportException;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
+import org.openmicroscopy.shoola.util.file.IOUtil;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 
@@ -115,7 +115,7 @@ public class StatusLabel extends JPanel implements PropertyChangeListener {
      */
     private String formatUpload(long value) {
         StringBuffer buffer = new StringBuffer();
-        String v = FileUtils.byteCountToDisplaySize(value);
+        String v = IOUtil.byteCountToDisplaySize(value);
         String[] values = v.split(" ");
         if (values.length > 1) {
             String u = values[1];

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/FileUploader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/FileUploader.java
@@ -21,17 +21,13 @@
 package org.openmicroscopy.shoola.env.data.views.calls;
 
 import java.io.File;
+import java.nio.file.StandardCopyOption;
 import java.util.Iterator;
 import java.util.List;
 
-import omero.model.IObject;
-import omero.model.OriginalFile;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
-
 import java.nio.file.Files;
 
+import com.google.common.io.MoreFiles;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.OmeroMetadataService;
 import omero.gateway.SecurityContext;
@@ -130,14 +126,14 @@ public class FileUploader
 					//Add the file to the directory.
 					if (f != null) {
 						directory = new File(directory.getParentFile(),
-								FilenameUtils.removeExtension(f.getName()));
-						FileUtils.copyFileToDirectory(f, directory, true);
+								MoreFiles.getNameWithoutExtension(f.toPath()));
+						Files.copy(f.toPath(), directory.toPath(), StandardCopyOption.REPLACE_EXISTING);
 					}
 					if (f != null) usedFiles = object.getUsedFiles();
 					if (usedFiles != null) {
 						for (int i = 0; i < usedFiles.length; i++) {
-							FileUtils.copyFileToDirectory(new File(usedFiles[i]),
-									directory, true);
+							Files.copy(new File(usedFiles[i]).toPath(),
+									directory.toPath(), StandardCopyOption.REPLACE_EXISTING);
 						}
 					}
 					if (id > 0) {
@@ -170,7 +166,7 @@ public class FileUploader
 				c.submitFile(token.toString(), f, object.getReaderType(),
 						new StringBuilder());
 				if (directory != null) {
-					FileUtils.deleteDirectory(directory);
+					MoreFiles.deleteRecursively(directory.toPath());
 					f.delete();
 				}
 			}

--- a/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ResultsSaver.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/data/views/calls/ResultsSaver.java
@@ -20,18 +20,19 @@
  */
 package org.openmicroscopy.shoola.env.data.views.calls;
 
+import com.google.common.io.MoreFiles;
 import ij.IJ;
 import ij.ImagePlus;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.env.data.OmeroImageService;
 import org.openmicroscopy.shoola.env.data.OmeroMetadataService;
 import org.openmicroscopy.shoola.env.data.model.FileObject;
@@ -88,11 +89,11 @@ public class ResultsSaver
             File dir = Files.createTempDirectory("ome_").toFile();
             String name;
             if (CommonsLangUtils.isBlank(fileName)) {
-                name = "ImageJ-"+FilenameUtils.getBaseName(
-                    FilenameUtils.removeExtension(img.getTitle()))+"-Results-";
+                name = "ImageJ-"+ MoreFiles.getNameWithoutExtension(Paths.get(img.getTitle()))
+                        +"-Results-";
                 name += new SimpleDateFormat("yyyy-MM-dd").format(new Date());
             } else {
-                name = FilenameUtils.removeExtension(fileName);
+                name = MoreFiles.getNameWithoutExtension(Paths.get(fileName));
             }
             name += ".csv";
             File f = new File(dir, name);

--- a/src/main/java/org/openmicroscopy/shoola/env/init/ContainerConfigInit.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/init/ContainerConfigInit.java
@@ -24,16 +24,16 @@
 package org.openmicroscopy.shoola.env.init;
 
 //Java imports
+import com.google.common.io.MoreFiles;
 import ij.IJ;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
 
 //Third-party libraries
 
-
-import org.apache.commons.io.FilenameUtils;
 //Application-internal dependencies
 import org.openmicroscopy.shoola.env.Container;
 import org.openmicroscopy.shoola.env.LookupNames;
@@ -96,7 +96,7 @@ public final class ContainerConfigInit
 				value = values[j];
 				if (value != null) value = value.trim();
 				if (l == null) continue;
-				value = FilenameUtils.removeExtension(value);
+				value = MoreFiles.getNameWithoutExtension(Paths.get(value));
 
 				for (int i = 0; i < l.length; i++) {
 					if (l[i].getName().startsWith(value)) {

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/ArchivedLoader.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/ArchivedLoader.java
@@ -27,8 +27,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.io.MoreFiles;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.FileUtils;
 import org.openmicroscopy.shoola.env.config.Registry;
 import omero.gateway.SecurityContext;
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
@@ -157,7 +157,7 @@ public class ArchivedLoader
                         f = i.next();
                         if (f.isDirectory()) {
                             try {
-                                FileUtils.deleteDirectory(f);
+                                MoreFiles.deleteRecursively(f.toPath());
                             } catch (Exception e) {
                                 registry.getLogger().error(this,
                                         "Cannot delete the directory");

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/DownloadAndZipActivity.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/DownloadAndZipActivity.java
@@ -26,8 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.io.FileUtils;
-
+import com.google.common.io.MoreFiles;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.model.DownloadAndZipParam;
 import omero.gateway.SecurityContext;
@@ -116,7 +115,7 @@ public class DownloadAndZipActivity
 	{
 	    try {
 	        messageLabel.setText(zipFolder.getAbsolutePath());
-	        FileUtils.deleteDirectory(zipFolder);
+			MoreFiles.deleteRecursively(zipFolder.toPath());
 	    } catch (Exception e) {
 	        registry.getLogger().error(this,
 	                "Error deleting folder:"+e.getMessage());

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/ExportActivity.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/ExportActivity.java
@@ -25,7 +25,6 @@ package org.openmicroscopy.shoola.env.ui;
 
 import java.io.File;
 
-import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 
 import org.openmicroscopy.shoola.env.config.Registry;

--- a/src/main/java/org/openmicroscopy/shoola/env/ui/SaveAsActivity.java
+++ b/src/main/java/org/openmicroscopy/shoola/env/ui/SaveAsActivity.java
@@ -21,11 +21,10 @@
 package org.openmicroscopy.shoola.env.ui;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Map;
 
-
-import org.apache.commons.io.FilenameUtils;
-
+import com.google.common.io.MoreFiles;
 import org.openmicroscopy.shoola.env.config.Registry;
 import org.openmicroscopy.shoola.env.data.model.SaveAsParam;
 import omero.gateway.SecurityContext;
@@ -70,7 +69,7 @@ public class SaveAsActivity
         File directory = parameters.getFolder();
         File[] files = directory.listFiles();
         String dirPath = directory.getAbsolutePath() + File.separator;
-        String extension = "."+FilenameUtils.getExtension(name);
+        String extension = "."+ MoreFiles.getFileExtension(Paths.get(name));
         return getFileName(files, name, name, dirPath, 1, extension);
     }
 

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/UIUtilities.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/UIUtilities.java
@@ -42,6 +42,7 @@ import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.Paths;
 import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -85,12 +86,12 @@ import javax.swing.text.StyledDocument;
 import javax.swing.text.TabSet;
 import javax.swing.text.TabStop;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
+import com.google.common.io.MoreFiles;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.jdesktop.swingx.JXDatePicker;
 import org.jdesktop.swingx.JXLabel;
 import org.jdesktop.swingx.JXTaskPane;
+import org.openmicroscopy.shoola.util.file.IOUtil;
 import org.openmicroscopy.shoola.util.ui.border.TitledLineBorder;
 
 import omero.model.Length;
@@ -1859,7 +1860,7 @@ public class UIUtilities
 	 */
 	public static String formatFileSize(long v)
 	{
-		return FileUtils.byteCountToDisplaySize(v);
+		return IOUtil.byteCountToDisplaySize(v);
 	}
 	
 	/**
@@ -2093,7 +2094,7 @@ public class UIUtilities
      */
     public static String removeFileExtension(String originalName)
     {
-    	return FilenameUtils.removeExtension(originalName);
+    	return MoreFiles.getNameWithoutExtension(Paths.get(originalName));
     }
     
 	/**

--- a/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/FileChooser.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/ui/filechooser/FileChooser.java
@@ -25,6 +25,7 @@ package org.openmicroscopy.shoola.util.ui.filechooser;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.regex.Pattern;
 import javax.swing.Icon;
@@ -35,8 +36,8 @@ import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.filechooser.FileFilter;
 
+import com.google.common.io.MoreFiles;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 
 import org.openmicroscopy.shoola.util.filter.file.CustomizedFileFilter;
@@ -344,7 +345,7 @@ public class FileChooser
             UIUtilities.setDefaultFolder(
                     uiDelegate.getCurrentDirectory().toString());
         File f = getSelectedFile();
-        String extension = FilenameUtils.getExtension(f.getName());
+        String extension = MoreFiles.getFileExtension(f.toPath());
         if (CommonsLangUtils.isBlank(extension)) {
             FileFilter filter = getSelectedFilter();
             if (filter instanceof CustomizedFileFilter) {
@@ -423,7 +424,7 @@ public class FileChooser
     {
         if (CommonsLangUtils.isBlank(name))
             throw new IllegalArgumentException("File name not valid.");
-        String s = FilenameUtils.getBaseName(name);
+        String s = MoreFiles.getNameWithoutExtension(Paths.get(name));
         if (CommonsLangUtils.isBlank(s)) s = name;
         uiDelegate.setSelectedFile(new File(s));
     }

--- a/src/test/java/org/openmicroscopy/shoola/util/file/TestIOUtil.java
+++ b/src/test/java/org/openmicroscopy/shoola/util/file/TestIOUtil.java
@@ -32,9 +32,8 @@ import java.nio.file.Paths;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
 
+import com.google.common.io.MoreFiles;
 import junit.framework.TestCase;
 
 
@@ -125,8 +124,8 @@ public class TestIOUtil
     private void clean(File f)
     {
         try {
-            if (f.isFile()) FileUtils.deleteQuietly(f);
-            if (f.isDirectory()) FileUtils.deleteDirectory(f);
+            if (f.isFile()) MoreFiles.deleteRecursively(f.toPath());
+            if (f.isDirectory()) MoreFiles.deleteRecursively(f.toPath());
         } catch (Exception e) {}
     }
 
@@ -139,7 +138,7 @@ public class TestIOUtil
             File dir = Files.createTempDirectory(prefix).toFile();
             File f = File.createTempFile("testZipDirectory", ".tmp", dir);
             File zip = IOUtil.zipDirectory(dir);
-            assertEquals(FilenameUtils.getExtension(zip.getName()), "zip");
+            assertEquals(MoreFiles.getFileExtension(zip.toPath()), "zip");
             File destDir = Files.createTempDirectory(prefix).toFile();
             boolean b = unzip(zip, destDir);
             assertEquals(true, b);
@@ -165,7 +164,7 @@ public class TestIOUtil
             File subfolder = Files.createTempDirectory(prefix).toFile();
             File f1 = File.createTempFile("sub_testZipDirectoryWithSubfolder", ".tmp", subfolder);
 
-            FileUtils.moveDirectoryToDirectory(subfolder, dir, false);
+            Files.copy(subfolder.toPath(), dir.toPath());
 
             File zip = IOUtil.zipDirectory(dir);
             File destDir = Files.createTempDirectory(prefix).toFile();


### PR DESCRIPTION
Equivalent to https://github.com/ome/omero-romio/pull/14 . But currently still fails because of the commons.io dep of omero-blitz.

It uses these replacements:
```
FilenameUtils.getBaseName -> MoreFiles.getNameWithoutExtension
FilenameUtils.getName -> Path.getFileName
FilenameUtils.getPath -> Path.toString
FilenameUtils.concat -> Paths.get
FilenameUtils.getExtension -> MoreFiles.getFileExtension
FilenameUtils.isExtension -> MoreFiles.getFileExtension
FilenameUtils.removeExtension -> MoreFiles.getNameWithoutExtension
FilenameUtils.getPrefix -> Path.getRoot

FileUtils.byteCountToDisplaySize -> own impl in IOUtil  (Returns a human-readable version of the file size)
FileUtils.copyURLToFile -> Files.copy
FileUtils.sizeOfDirectory -> own impl in IOUtil  (Counts the size of a directory recursively)
FileUtils.forceMkdir -> Files.createDirectory
FileUtils.deleteDirectory ->  MoreFiles.deleteRecursively
FileUtils.copyFile -> Files.copy
FileUtils.copyFileToDirectory -> Files.copy
FileUtils.moveFileToDirectory -> Files.move
FileUtils.writeStringToFile -> Files.write
FileUtils.readFileToString -> Files.readLines
```