### PR TITLE
Remove duplicate app_name parameter

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/svc/proxy/MessengerRequest.java
+++ b/src/main/java/org/openmicroscopy/shoola/svc/proxy/MessengerRequest.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.svc.proxy.MessengerRequest 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2024 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -169,8 +169,6 @@ class MessengerRequest
         p.add(new BasicNameValuePair(ERROR, error));
         p.add(new BasicNameValuePair(EXTRA, extra));
         p.add(new BasicNameValuePair(INVOKER, invoker));
-        p.add(new BasicNameValuePair(ProxyUtil.APP_NAME,
-                applicationNumber));
         p.add(new BasicNameValuePair(ProxyUtil.APP_NAME, applicationNumber));
         p.add(new BasicNameValuePair(ProxyUtil.APP_VERSION, applicationVersion));
         


### PR DESCRIPTION
The `app_name` parameter was included twice. For some reason that caused the failure to send to the new QA.

~~Not ready to merge yet, I want to still check why Insight ignored the error and gave user the wrong impression that the feedback was sent.~~
