### PR TITLE
Adjust the upload and download of artifacts v4

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -78,28 +78,28 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu') && startsWith(github.ref, 'refs/tags') && startsWith(matrix.java, '8')
         uses: actions/upload-artifact@v4
         with:
-            name: artifacts
+            name: artifacts-${{ matrix.os }}-OMERO
             path: build/distributions/OMERO*
             if-no-files-found: error
       - name: Upload jar
         if: startsWith(matrix.os, 'ubuntu') && startsWith(github.ref, 'refs/tags') && startsWith(matrix.java, '8')
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.os }}-omero_
           path: build/libs/omero_*
           if-no-files-found: error
       - name: Upload insight artifacts
         if: startsWith(matrix.os, 'windows') && startsWith(github.ref, 'refs/tags') && startsWith(matrix.java, '8')
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.os }}-insight
           path: build/packaged/main/bundles/*
           if-no-files-found: error
       - name: Upload importer artifacts
         if: startsWith(matrix.os, 'windows') && startsWith(github.ref, 'refs/tags') && startsWith(matrix.java, '8')
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.os }}-importer
           path: build/packaged/installImporterDist/bundles/*
 
   release:
@@ -115,7 +115,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: artifacts/*
+          file: artifacts*/*
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true


### PR DESCRIPTION
This is trying to address https://github.com/ome/omero-insight/issues/447

This branch starts from the https://github.com/ome/omero-insight/actions/runs/10884718399 - the commit a3ea82d1e59e2630ca3995ee9776a292f74e12ea -> where the build started to fail because of the same-named artifacts.

The strategy taken:

Upload:
1. add the ``matrix.os`` motif to the artifact name -> this is by itself not enough, as we build 2 artifacts per OS on 2 occassions
2. add a hardcoded string such as ``omero_`` which is taken from the foldername of the ``path`` variable just below the ``name`` of the artifact

Download:
1. adjust the ``file: artifacts/*`` -> ``file: artifacts*/*`` so that the artifacts are found in all folders created during Upload.

I have pushed an xxx-test8 tag to my [private branch show-tagged-artifacts](https://github.com/pwalczysko/omero-insight/tree/show-tagged-artifacts) (because I do not want to push tags to this branch so as not to trigger a real release) and this resulted in [Release with artifacts](https://github.com/pwalczysko/omero-insight/releases/tag/v5.8.5-test8)


cc @jburel 