### PR TITLE
ImageJ usage: Check the class of the correct variable

### DIFF
--- a/src/main/java/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
+++ b/src/main/java/org/openmicroscopy/shoola/util/roi/io/ROIReader.java
@@ -381,7 +381,7 @@ public class ROIReader {
                         if (shape != null) {
                             roiData.addShapeData(shape);
                         }
-                    } else if (shapeij instanceof PolygonRoi || r instanceof EllipseRoi) {
+                    } else if (shapeij instanceof PolygonRoi || shapeij instanceof EllipseRoi) {
                         if (type.matches("Point")) {
                             convertPoint((PointRoi) shapeij, roiData);
                         } else if (type.matches("Polyline") ||


### PR DESCRIPTION
This PR fixes the problem reported in #486.
The problem happens when a collection of ImageJ shapes is collected and converted.
