### PR TITLE
Bump org.openmicroscopy:omero-gateway from 5.9.3 to 5.10.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,12 +48,11 @@ dependencies {
     implementation("org.jfree:jfreechart:1.0.19")
     implementation("org.swinglabs:swingx:1.6.1")
 
-    implementation("org.openmicroscopy:omero-gateway:5.9.3") {
+    implementation("org.openmicroscopy:omero-gateway:5.10.5") {
         // Conflicts with `net.java.dev.jna`
         exclude group: "com.sun.jna", module: "jna"
     }
-    implementation("ch.qos.logback:logback-classic:1.3.14")
-    implementation("ch.qos.logback:logback-core:1.3.14")
+    implementation("ch.qos.logback:logback-classic:1.3.16")
 }
 
 test {


### PR DESCRIPTION
Brings the latest released version of Bio-Formats, see https://www.openmicroscopy.org/2026/01/15/bio-formats-8-4-0.html